### PR TITLE
build multi arch docker image

### DIFF
--- a/admin/admin-api/.gitlab-ci.yml
+++ b/admin/admin-api/.gitlab-ci.yml
@@ -77,9 +77,9 @@ publish-admin-api-image:
   script:
     - TAG=buildx-test
     # - TAG=${CI_COMMIT_TAG#admin-api-v}
-    - docker buildx build --push --platform ${BUILDX_PLATFORM} --tag $IMAGE_PROJECT_NAME:$TAG --tag $IMAGE_PROJECT_NAME:$TAG-latest admin/admin-api
-    - docker tag $IMAGE_PROJECT_NAME:$TAG $IMAGE_PROJECT_NAME:latest
-    - docker push $IMAGE_PROJECT_NAME:latest
+    - docker buildx build --push --platform ${BUILDX_PLATFORM} \
+      --tag $IMAGE_PROJECT_NAME:$TAG \
+      admin/admin-api
 #   rules:
 #     - if: '$CI_COMMIT_TAG =~ /^admin-api-v\d*.\d*.\d*$/'
 #       when: always

--- a/admin/admin-api/.gitlab-ci.yml
+++ b/admin/admin-api/.gitlab-ci.yml
@@ -47,21 +47,38 @@ release-admin-api:
 
 publish-admin-api-image:
   stage: publish-image
-  image: docker:18-git
+  image: docker:19
   services:
-    - docker:18-dind
+    - name: docker:19.03.6-dind
+      command: ["--experimental"]
+
   variables:
     IMAGE_PROJECT_NAME: "konstellation/kre-admin-api"
     DOCKER_USER: $DOCKER_USER
     DOCKER_PASS: $DOCKER_PASS
+    DOCKER_HOST: tcp://docker:2375
+    DOCKER_DRIVER: overlay2
+    DOCKER_BUILDKIT: 1
+    DOCKER_CLI_EXPERIMENTAL: enabled
+    BUILDX_URL: https://github.com/docker/buildx/releases/download/v0.3.1/buildx-v0.3.1.linux-amd64
+    BUILDX_BUILDER: multiarch
+    BUILDX_PLATFORM: linux/amd64,linux/arm64
+
   before_script:
+    - mkdir -p $HOME/.docker/cli-plugins/
+    - wget -O $HOME/.docker/cli-plugins/docker-buildx $BUILDX_URL
+    - chmod a+x $HOME/.docker/cli-plugins/docker-buildx
+    - "echo -e '{\n  \"experimental\": \"enabled\"\n}' | tee $HOME/.docker/config.json"
+    - docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+    - docker buildx create --use --driver docker-container --name ${BUILDX_BUILDER} --platform=${BUILDX_PLATFORM}
+    - docker buildx inspect --bootstrap ${BUILDX_BUILDER}
+    - docker buildx ls
     - docker login -u $DOCKER_USER -p $DOCKER_PASS
   script:
     - TAG=${CI_COMMIT_TAG#admin-api-v}
-    - docker build -t $IMAGE_PROJECT_NAME:$TAG admin/admin-api
+    - docker buildx build --push --platform=${BUILDX_PLATFORM} -t $IMAGE_PROJECT_NAME:$TAG admin/admin-api .
     - docker tag $IMAGE_PROJECT_NAME:$TAG $IMAGE_PROJECT_NAME:latest
-    - docker push $IMAGE_PROJECT_NAME:$TAG
     - docker push $IMAGE_PROJECT_NAME:latest
-  rules:
-    - if: '$CI_COMMIT_TAG =~ /^admin-api-v\d*.\d*.\d*$/'
-      when: always
+  # rules:
+  #   - if: '$CI_COMMIT_TAG =~ /^admin-api-v\d*.\d*.\d*$/'
+  #     when: always

--- a/admin/admin-api/.gitlab-ci.yml
+++ b/admin/admin-api/.gitlab-ci.yml
@@ -75,7 +75,8 @@ publish-admin-api-image:
     - docker buildx ls
     - docker login -u $DOCKER_USER -p $DOCKER_PASS
   script:
-    - TAG=${CI_COMMIT_TAG#admin-api-v}
+    - TAG=buildx-test
+    # - TAG=${CI_COMMIT_TAG#admin-api-v}
     - docker buildx build --push --platform ${BUILDX_PLATFORM} --tag $IMAGE_PROJECT_NAME:$TAG admin/admin-api
     - docker tag $IMAGE_PROJECT_NAME:$TAG $IMAGE_PROJECT_NAME:latest
     - docker push $IMAGE_PROJECT_NAME:latest

--- a/admin/admin-api/.gitlab-ci.yml
+++ b/admin/admin-api/.gitlab-ci.yml
@@ -76,7 +76,7 @@ publish-admin-api-image:
     - docker login -u $DOCKER_USER -p $DOCKER_PASS
   script:
     - TAG=${CI_COMMIT_TAG#admin-api-v}
-    - docker buildx build --push --platform ${BUILDX_PLATFORM} --tag $IMAGE_PROJECT_NAME:$TAG admin/admin-api .
+    - docker buildx build --push --platform ${BUILDX_PLATFORM} --tag $IMAGE_PROJECT_NAME:$TAG admin/admin-api
     - docker tag $IMAGE_PROJECT_NAME:$TAG $IMAGE_PROJECT_NAME:latest
     - docker push $IMAGE_PROJECT_NAME:latest
   # rules:

--- a/admin/admin-api/.gitlab-ci.yml
+++ b/admin/admin-api/.gitlab-ci.yml
@@ -75,11 +75,11 @@ publish-admin-api-image:
     - docker buildx ls
     - docker login -u $DOCKER_USER -p $DOCKER_PASS
   script:
-    - TAG=buildx-test
-    # - TAG=${CI_COMMIT_TAG#admin-api-v}
+    - TAG=${CI_COMMIT_TAG#admin-api-v}
     - docker buildx build --push --platform ${BUILDX_PLATFORM}
       --tag $IMAGE_PROJECT_NAME:$TAG
+      --tag $IMAGE_PROJECT_NAME:latest
       admin/admin-api
-#   rules:
-#     - if: '$CI_COMMIT_TAG =~ /^admin-api-v\d*.\d*.\d*$/'
-#       when: always
+  rules:
+    - if: '$CI_COMMIT_TAG =~ /^admin-api-v\d*.\d*.\d*$/'
+      when: always

--- a/admin/admin-api/.gitlab-ci.yml
+++ b/admin/admin-api/.gitlab-ci.yml
@@ -62,7 +62,7 @@ publish-admin-api-image:
     DOCKER_CLI_EXPERIMENTAL: enabled
     BUILDX_URL: https://github.com/docker/buildx/releases/download/v0.3.1/buildx-v0.3.1.linux-amd64
     BUILDX_BUILDER: multiarch
-    BUILDX_PLATFORM: linux/amd64,linux/arm64
+    BUILDX_PLATFORM: "linux/amd64,linux/arm64"
 
   before_script:
     - mkdir -p $HOME/.docker/cli-plugins/
@@ -76,7 +76,7 @@ publish-admin-api-image:
     - docker login -u $DOCKER_USER -p $DOCKER_PASS
   script:
     - TAG=${CI_COMMIT_TAG#admin-api-v}
-    - docker buildx build --push --platform=${BUILDX_PLATFORM} -t $IMAGE_PROJECT_NAME:$TAG admin/admin-api .
+    - docker buildx build --push --platform ${BUILDX_PLATFORM} --tag $IMAGE_PROJECT_NAME:$TAG admin/admin-api .
     - docker tag $IMAGE_PROJECT_NAME:$TAG $IMAGE_PROJECT_NAME:latest
     - docker push $IMAGE_PROJECT_NAME:latest
   # rules:

--- a/admin/admin-api/.gitlab-ci.yml
+++ b/admin/admin-api/.gitlab-ci.yml
@@ -77,8 +77,8 @@ publish-admin-api-image:
   script:
     - TAG=buildx-test
     # - TAG=${CI_COMMIT_TAG#admin-api-v}
-    - docker buildx build --push --platform ${BUILDX_PLATFORM} \
-      --tag $IMAGE_PROJECT_NAME:$TAG \
+    - docker buildx build --push --platform ${BUILDX_PLATFORM}
+      --tag $IMAGE_PROJECT_NAME:$TAG
       admin/admin-api
 #   rules:
 #     - if: '$CI_COMMIT_TAG =~ /^admin-api-v\d*.\d*.\d*$/'

--- a/admin/admin-api/.gitlab-ci.yml
+++ b/admin/admin-api/.gitlab-ci.yml
@@ -77,9 +77,9 @@ publish-admin-api-image:
   script:
     - TAG=buildx-test
     # - TAG=${CI_COMMIT_TAG#admin-api-v}
-    - docker buildx build --push --platform ${BUILDX_PLATFORM} --tag $IMAGE_PROJECT_NAME:$TAG admin/admin-api
+    - docker buildx build --push --platform ${BUILDX_PLATFORM} --tag $IMAGE_PROJECT_NAME:$TAG --tag $IMAGE_PROJECT_NAME:$TAG-latest admin/admin-api
     - docker tag $IMAGE_PROJECT_NAME:$TAG $IMAGE_PROJECT_NAME:latest
     - docker push $IMAGE_PROJECT_NAME:latest
-  # rules:
-  #   - if: '$CI_COMMIT_TAG =~ /^admin-api-v\d*.\d*.\d*$/'
-  #     when: always
+#   rules:
+#     - if: '$CI_COMMIT_TAG =~ /^admin-api-v\d*.\d*.\d*$/'
+#       when: always

--- a/admin/admin-ui/.gitlab-ci.yml
+++ b/admin/admin-ui/.gitlab-ci.yml
@@ -80,8 +80,8 @@ publish-admin-ui-image:
     - docker run --rm -v `pwd`/admin/admin-ui:/app -w /app node:14 sh -c 'yarn install && yarn run build'
     - TAG=buildx-test
     # - TAG=${CI_COMMIT_TAG#admin-ui-v}
-    - docker buildx build --push --platform ${BUILDX_PLATFORM} \
-      --tag $IMAGE_PROJECT_NAME:$TAG \
+    - docker buildx build --push --platform ${BUILDX_PLATFORM}
+      --tag $IMAGE_PROJECT_NAME:$TAG
       admin/admin-ui
 #  rules:
 #    - if: '$CI_COMMIT_TAG =~ /^admin-ui-v\d*.\d*.\d*$/'

--- a/admin/admin-ui/.gitlab-ci.yml
+++ b/admin/admin-ui/.gitlab-ci.yml
@@ -49,21 +49,40 @@ release-admin-ui:
 
 publish-admin-ui-image:
   stage: publish-image
-  image: docker:18-git
+  image: docker:19
   services:
-    - docker:18-dind
+    - name: docker:19.03.6-dind
+      command: ["--experimental"]
+
   variables:
     IMAGE_PROJECT_NAME: 'konstellation/kre-admin-ui'
     DOCKER_USER: $DOCKER_USER
     DOCKER_PASS: $DOCKER_PASS
+    DOCKER_HOST: tcp://docker:2375
+    DOCKER_DRIVER: overlay2
+    DOCKER_BUILDKIT: 1
+    DOCKER_CLI_EXPERIMENTAL: enabled
+    BUILDX_URL: https://github.com/docker/buildx/releases/download/v0.3.1/buildx-v0.3.1.linux-amd64
+    BUILDX_BUILDER: multiarch
+    BUILDX_PLATFORM: "linux/amd64,linux/arm64"
+
   before_script:
+    - mkdir -p $HOME/.docker/cli-plugins/
+    - wget -O $HOME/.docker/cli-plugins/docker-buildx $BUILDX_URL
+    - chmod a+x $HOME/.docker/cli-plugins/docker-buildx
+    - docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+    - docker buildx create --use --driver docker-container --name ${BUILDX_BUILDER} --platform=${BUILDX_PLATFORM}
+    - docker buildx inspect --bootstrap ${BUILDX_BUILDER}
+    - docker buildx ls
     - docker login -u $DOCKER_USER -p $DOCKER_PASS
   script:
-    - TAG=${CI_COMMIT_TAG#admin-ui-v}
-    - docker build -t $IMAGE_PROJECT_NAME:$TAG admin/admin-ui
-    - docker tag $IMAGE_PROJECT_NAME:$TAG $IMAGE_PROJECT_NAME:latest
-    - docker push $IMAGE_PROJECT_NAME:$TAG
-    - docker push $IMAGE_PROJECT_NAME:latest
-  rules:
-    - if: '$CI_COMMIT_TAG =~ /^admin-ui-v\d*.\d*.\d*$/'
-      when: always
+    # Generate statics
+    - docker run --rm -v `pwd`/admin/admin-ui:/app -w /app node:14 sh -c 'yarn install && yarn run build'
+    - TAG=buildx-test
+    # - TAG=${CI_COMMIT_TAG#admin-ui-v}
+    - docker buildx build --push --platform ${BUILDX_PLATFORM} \
+      --tag $IMAGE_PROJECT_NAME:$TAG \
+      admin/admin-ui
+#  rules:
+#    - if: '$CI_COMMIT_TAG =~ /^admin-ui-v\d*.\d*.\d*$/'
+#      when: always

--- a/admin/admin-ui/.gitlab-ci.yml
+++ b/admin/admin-ui/.gitlab-ci.yml
@@ -77,12 +77,12 @@ publish-admin-ui-image:
     - docker login -u $DOCKER_USER -p $DOCKER_PASS
   script:
     # Generate statics
-    - docker run --rm -v `pwd`/admin/admin-ui:/app -w /app node:14 sh -c 'yarn install && yarn run build'
-    - TAG=buildx-test
-    # - TAG=${CI_COMMIT_TAG#admin-ui-v}
+    - docker run --rm -v `pwd`/admin/admin-ui/:/app -w /app node:14 sh -c 'yarn install && yarn run build'
+    - TAG=${CI_COMMIT_TAG#admin-ui-v}
     - docker buildx build --push --platform ${BUILDX_PLATFORM}
       --tag $IMAGE_PROJECT_NAME:$TAG
+      --tag $IMAGE_PROJECT_NAME:latest
       admin/admin-ui
-#  rules:
-#    - if: '$CI_COMMIT_TAG =~ /^admin-ui-v\d*.\d*.\d*$/'
-#      when: always
+  rules:
+    - if: '$CI_COMMIT_TAG =~ /^admin-ui-v\d*.\d*.\d*$/'
+      when: always

--- a/admin/admin-ui/Dockerfile
+++ b/admin/admin-ui/Dockerfile
@@ -1,16 +1,6 @@
-FROM node:14 as front-builder
-
-ARG VERSION
-WORKDIR /app
-COPY package.* ./
-COPY yarn* ./
-RUN yarn install
-RUN npm version $VERSION
-COPY . .
-RUN yarn run build
 FROM nginx:alpine
 
-COPY --from=front-builder /app/build /usr/share/nginx/html
+COPY ./build /usr/share/nginx/html
 COPY nginx.conf /etc/nginx/conf.d/default.conf
 EXPOSE 80
 CMD ["nginx", "-g", "daemon off;"]

--- a/admin/k8s-manager/.gitlab-ci.yml
+++ b/admin/k8s-manager/.gitlab-ci.yml
@@ -42,7 +42,7 @@ publish-k8s-manager-image:
     - docker login -u $DOCKER_USER -p $DOCKER_PASS
 
   script:
-    - TAG=buildx-test
+    - TAG=buildx
     # - TAG=${CI_COMMIT_TAG#k8s-manager-v}
     - docker buildx build --push --platform ${BUILDX_PLATFORM}
       --tag $IMAGE_PROJECT_NAME:$TAG

--- a/admin/k8s-manager/.gitlab-ci.yml
+++ b/admin/k8s-manager/.gitlab-ci.yml
@@ -42,11 +42,11 @@ publish-k8s-manager-image:
     - docker login -u $DOCKER_USER -p $DOCKER_PASS
 
   script:
-    - TAG=buildx
-    # - TAG=${CI_COMMIT_TAG#k8s-manager-v}
+    - TAG=${CI_COMMIT_TAG#k8s-manager-v}
     - docker buildx build --push --platform ${BUILDX_PLATFORM}
       --tag $IMAGE_PROJECT_NAME:$TAG
+      --tag $IMAGE_PROJECT_NAME:latest
       admin/k8s-manager
-#  rules:
-#    - if: '$CI_COMMIT_TAG =~ /^k8s-manager-v\d*.\d*.\d*$/'
-#      when: always
+  rules:
+    - if: '$CI_COMMIT_TAG =~ /^k8s-manager-v\d*.\d*.\d*$/'
+      when: always

--- a/admin/k8s-manager/.gitlab-ci.yml
+++ b/admin/k8s-manager/.gitlab-ci.yml
@@ -14,21 +14,39 @@ release-k8s-manager:
 
 publish-k8s-manager-image:
   stage: publish-image
-  image: docker:18-git
+  image: docker:19
   services:
-    - docker:18-dind
+    - name: docker:19.03.6-dind
+      command: ["--experimental"]
+
   variables:
     IMAGE_PROJECT_NAME: "konstellation/kre-k8s-manager"
     DOCKER_USER: $DOCKER_USER
     DOCKER_PASS: $DOCKER_PASS
+    DOCKER_HOST: tcp://docker:2375
+    DOCKER_DRIVER: overlay2
+    DOCKER_BUILDKIT: 1
+    DOCKER_CLI_EXPERIMENTAL: enabled
+    BUILDX_URL: https://github.com/docker/buildx/releases/download/v0.3.1/buildx-v0.3.1.linux-amd64
+    BUILDX_BUILDER: multiarch
+    BUILDX_PLATFORM: "linux/amd64,linux/arm64"
+
   before_script:
+    - mkdir -p $HOME/.docker/cli-plugins/
+    - wget -O $HOME/.docker/cli-plugins/docker-buildx $BUILDX_URL
+    - chmod a+x $HOME/.docker/cli-plugins/docker-buildx
+    - docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+    - docker buildx create --use --driver docker-container --name ${BUILDX_BUILDER} --platform=${BUILDX_PLATFORM}
+    - docker buildx inspect --bootstrap ${BUILDX_BUILDER}
+    - docker buildx ls
     - docker login -u $DOCKER_USER -p $DOCKER_PASS
+
   script:
-    - TAG=${CI_COMMIT_TAG#k8s-manager-v}
-    - docker build -t $IMAGE_PROJECT_NAME:$TAG admin/k8s-manager
-    - docker tag $IMAGE_PROJECT_NAME:$TAG $IMAGE_PROJECT_NAME:latest
-    - docker push $IMAGE_PROJECT_NAME:$TAG
-    - docker push $IMAGE_PROJECT_NAME:latest
-  rules:
-    - if: '$CI_COMMIT_TAG =~ /^k8s-manager-v\d*.\d*.\d*$/'
-      when: always
+    - TAG=buildx-test
+    # - TAG=${CI_COMMIT_TAG#k8s-manager-v}
+    - docker buildx build --push --platform ${BUILDX_PLATFORM}
+      --tag $IMAGE_PROJECT_NAME:$TAG
+      admin/k8s-manager
+#  rules:
+#    - if: '$CI_COMMIT_TAG =~ /^k8s-manager-v\d*.\d*.\d*$/'
+#      when: always

--- a/runtime/k8s-runtime-operator/.gitlab-ci.yml
+++ b/runtime/k8s-runtime-operator/.gitlab-ci.yml
@@ -14,29 +14,42 @@ release-k8s-runtime-operator:
 
 publish-k8s-runtime-operator-image:
   stage: publish-image
-  image: docker:18-git
+  image: docker:19
   services:
-    - docker:18-dind
+    - name: docker:19.03.6-dind
+      command: ["--experimental"]
+
   variables:
     SDK_RELEASE_VERSION: v0.15.1
     HELM_VERSION: v3.0.3
     IMAGE_PROJECT_NAME: "konstellation/kre-k8s-runtime-operator"
     DOCKER_USER: $DOCKER_USER
     DOCKER_PASS: $DOCKER_PASS
+    DOCKER_HOST: tcp://docker:2375
+    DOCKER_DRIVER: overlay2
+    DOCKER_BUILDKIT: 1
+    DOCKER_CLI_EXPERIMENTAL: enabled
+    BUILDX_URL: https://github.com/docker/buildx/releases/download/v0.3.1/buildx-v0.3.1.linux-amd64
+    BUILDX_BUILDER: multiarch
+    BUILDX_PLATFORM: "linux/amd64,linux/arm64"
   before_script:
-    - docker login -u $DOCKER_USER -p $DOCKER_PASS
     - cd runtime/k8s-runtime-operator
-    - ./scripts/install_operator_sdk.sh
     - wget -q https://get.helm.sh/helm-${HELM_VERSION}-linux-amd64.tar.gz -O - | tar -xzO linux-amd64/helm > /usr/local/bin/helm
     - chmod +x /usr/local/bin/helm
     - helm repo add stable https://kubernetes-charts.storage.googleapis.com
     - helm dependency update helm-charts/kre-chart
+    - mkdir -p $HOME/.docker/cli-plugins/
+    - wget -O $HOME/.docker/cli-plugins/docker-buildx $BUILDX_URL
+    - chmod a+x $HOME/.docker/cli-plugins/docker-buildx
+    - docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+    - docker buildx create --use --driver docker-container --name ${BUILDX_BUILDER} --platform=${BUILDX_PLATFORM}
+    - docker buildx inspect --bootstrap ${BUILDX_BUILDER}
+    - docker buildx ls
+    - docker login -u $DOCKER_USER -p $DOCKER_PASS
   script:
-    - TAG=${CI_COMMIT_TAG#k8s-runtime-operator-v}
-    - operator-sdk build $IMAGE_PROJECT_NAME:$TAG
-    - docker tag $IMAGE_PROJECT_NAME:$TAG $IMAGE_PROJECT_NAME:latest
-    - docker push $IMAGE_PROJECT_NAME:$TAG
-    - docker push $IMAGE_PROJECT_NAME:latest
-  rules:
-    - if: '$CI_COMMIT_TAG =~ /^k8s-runtime-operator-v\d*.\d*.\d*$/'
-      when: always
+    - TAG=buildx-test
+    # - TAG=${CI_COMMIT_TAG#k8s-runtime-operator-v}
+    - docker buildx build --push --platform ${BUILDX_PLATFORM} --tag $IMAGE_PROJECT_NAME:$TAG .
+#  rules:
+#    - if: '$CI_COMMIT_TAG =~ /^k8s-runtime-operator-v\d*.\d*.\d*$/'
+#      when: always

--- a/runtime/k8s-runtime-operator/.gitlab-ci.yml
+++ b/runtime/k8s-runtime-operator/.gitlab-ci.yml
@@ -47,9 +47,11 @@ publish-k8s-runtime-operator-image:
     - docker buildx ls
     - docker login -u $DOCKER_USER -p $DOCKER_PASS
   script:
-    - TAG=buildx-test
-    # - TAG=${CI_COMMIT_TAG#k8s-runtime-operator-v}
-    - docker buildx build --push --platform ${BUILDX_PLATFORM} --tag $IMAGE_PROJECT_NAME:$TAG .
-#  rules:
-#    - if: '$CI_COMMIT_TAG =~ /^k8s-runtime-operator-v\d*.\d*.\d*$/'
-#      when: always
+    - TAG=${CI_COMMIT_TAG#k8s-runtime-operator-v}
+    - docker buildx build --push --platform ${BUILDX_PLATFORM}
+      --tag $IMAGE_PROJECT_NAME:$TAG
+      --tag $IMAGE_PROJECT_NAME:latest
+      .
+  rules:
+    - if: '$CI_COMMIT_TAG =~ /^k8s-runtime-operator-v\d*.\d*.\d*$/'
+      when: always

--- a/runtime/k8s-runtime-operator/Dockerfile
+++ b/runtime/k8s-runtime-operator/Dockerfile
@@ -1,0 +1,4 @@
+FROM quay.io/operator-framework/helm-operator:v0.17.0
+
+COPY watches.yaml ${HOME}/watches.yaml
+COPY ./helm-charts/ /opt/helm/helm-charts/

--- a/runtime/mongo-writer/.gitlab-ci.yml
+++ b/runtime/mongo-writer/.gitlab-ci.yml
@@ -53,11 +53,11 @@ publish-mongo-writer-image:
     - docker buildx ls
     - docker login -u $DOCKER_USER -p $DOCKER_PASS
   script:
-    - TAG=buildx
-    # - TAG=${CI_COMMIT_TAG#mongo-writer-v}
+    - TAG=${CI_COMMIT_TAG#mongo-writer-v}
     - docker buildx build --push --platform ${BUILDX_PLATFORM}
       --tag $IMAGE_PROJECT_NAME:$TAG
+      --tag $IMAGE_PROJECT_NAME:latest
       runtime/mongo-writer
-#  rules:
-#    - if: '$CI_COMMIT_TAG =~ /^mongo-writer-v\d*.\d*.\d*$/'
-#      when: always
+  rules:
+    - if: '$CI_COMMIT_TAG =~ /^mongo-writer-v\d*.\d*.\d*$/'
+      when: always

--- a/runtime/mongo-writer/.gitlab-ci.yml
+++ b/runtime/mongo-writer/.gitlab-ci.yml
@@ -27,23 +27,37 @@ release-mongo-writer:
 
 publish-mongo-writer-image:
   stage: publish-image
-  image: docker:18-git
+  image: docker:19
   services:
-    - docker:18-dind
+    - name: docker:19.03.6-dind
+      command: ["--experimental"]
+
   variables:
     IMAGE_PROJECT_NAME: "konstellation/kre-mongo-writer"
     DOCKER_USER: $DOCKER_USER
     DOCKER_PASS: $DOCKER_PASS
+    DOCKER_HOST: tcp://docker:2375
+    DOCKER_DRIVER: overlay2
+    DOCKER_BUILDKIT: 1
+    DOCKER_CLI_EXPERIMENTAL: enabled
+    BUILDX_URL: https://github.com/docker/buildx/releases/download/v0.3.1/buildx-v0.3.1.linux-amd64
+    BUILDX_BUILDER: multiarch
+    BUILDX_PLATFORM: "linux/amd64,linux/arm64"
   before_script:
-    - apk add nodejs npm --update
+    - mkdir -p $HOME/.docker/cli-plugins/
+    - wget -O $HOME/.docker/cli-plugins/docker-buildx $BUILDX_URL
+    - chmod a+x $HOME/.docker/cli-plugins/docker-buildx
+    - docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+    - docker buildx create --use --driver docker-container --name ${BUILDX_BUILDER} --platform=${BUILDX_PLATFORM}
+    - docker buildx inspect --bootstrap ${BUILDX_BUILDER}
+    - docker buildx ls
     - docker login -u $DOCKER_USER -p $DOCKER_PASS
   script:
-    - TAG=${CI_COMMIT_TAG#mongo-writer-v}
-    - docker build -t $IMAGE_PROJECT_NAME:$TAG mongo-writer
-    # IMAGE SECURITY CHECK
-    - docker tag $IMAGE_PROJECT_NAME:$TAG $IMAGE_PROJECT_NAME:latest
-    - docker push $IMAGE_PROJECT_NAME:$TAG
-    - docker push $IMAGE_PROJECT_NAME:latest
-  rules:
-    - if: '$CI_COMMIT_TAG =~ /^mongo-writer-v\d*.\d*.\d*$/'
-      when: always
+    - TAG=buildx
+    # - TAG=${CI_COMMIT_TAG#mongo-writer-v}
+    - docker buildx build --push --platform ${BUILDX_PLATFORM}
+      --tag $IMAGE_PROJECT_NAME:$TAG
+      runtime/mongo-writer
+#  rules:
+#    - if: '$CI_COMMIT_TAG =~ /^mongo-writer-v\d*.\d*.\d*$/'
+#      when: always

--- a/runtime/runtime-api/.gitlab-ci.yml
+++ b/runtime/runtime-api/.gitlab-ci.yml
@@ -73,11 +73,11 @@ publish-runtime-api-image:
     - docker buildx ls
     - docker login -u $DOCKER_USER -p $DOCKER_PASS
   script:
-    - TAG=buildx
-    # - TAG=${CI_COMMIT_TAG#runtime-api-v}
+    - TAG=${CI_COMMIT_TAG#runtime-api-v}
     - docker buildx build --push --platform ${BUILDX_PLATFORM}
       --tag $IMAGE_PROJECT_NAME:$TAG
+      --tag $IMAGE_PROJECT_NAME:latest
       runtime/runtime-api
-#  rules:
-#    - if: '$CI_COMMIT_TAG =~ /^runtime-api-v\d*.\d*.\d*$/'
-#      when: always
+  rules:
+    - if: '$CI_COMMIT_TAG =~ /^runtime-api-v\d*.\d*.\d*$/'
+      when: always

--- a/runtime/runtime-api/.gitlab-ci.yml
+++ b/runtime/runtime-api/.gitlab-ci.yml
@@ -47,21 +47,37 @@ release-runtime-api:
 
 publish-runtime-api-image:
   stage: publish-image
-  image: docker:18-git
+  image: docker:19
   services:
-    - docker:18-dind
+    - name: docker:19.03.6-dind
+      command: ["--experimental"]
+
   variables:
     IMAGE_PROJECT_NAME: "konstellation/kre-runtime-api"
     DOCKER_USER: $DOCKER_USER
     DOCKER_PASS: $DOCKER_PASS
+    DOCKER_HOST: tcp://docker:2375
+    DOCKER_DRIVER: overlay2
+    DOCKER_BUILDKIT: 1
+    DOCKER_CLI_EXPERIMENTAL: enabled
+    BUILDX_URL: https://github.com/docker/buildx/releases/download/v0.3.1/buildx-v0.3.1.linux-amd64
+    BUILDX_BUILDER: multiarch
+    BUILDX_PLATFORM: "linux/amd64,linux/arm64"
   before_script:
+    - mkdir -p $HOME/.docker/cli-plugins/
+    - wget -O $HOME/.docker/cli-plugins/docker-buildx $BUILDX_URL
+    - chmod a+x $HOME/.docker/cli-plugins/docker-buildx
+    - docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+    - docker buildx create --use --driver docker-container --name ${BUILDX_BUILDER} --platform=${BUILDX_PLATFORM}
+    - docker buildx inspect --bootstrap ${BUILDX_BUILDER}
+    - docker buildx ls
     - docker login -u $DOCKER_USER -p $DOCKER_PASS
   script:
-    - TAG=${CI_COMMIT_TAG#runtime-api-v}
-    - docker build -t $IMAGE_PROJECT_NAME:$TAG runtime/runtime-api
-    - docker tag $IMAGE_PROJECT_NAME:$TAG $IMAGE_PROJECT_NAME:latest
-    - docker push $IMAGE_PROJECT_NAME:$TAG
-    - docker push $IMAGE_PROJECT_NAME:latest
-  rules:
-    - if: '$CI_COMMIT_TAG =~ /^runtime-api-v\d*.\d*.\d*$/'
-      when: always
+    - TAG=buildx
+    # - TAG=${CI_COMMIT_TAG#runtime-api-v}
+    - docker buildx build --push --platform ${BUILDX_PLATFORM}
+      --tag $IMAGE_PROJECT_NAME:$TAG
+      runtime/runtime-api
+#  rules:
+#    - if: '$CI_COMMIT_TAG =~ /^runtime-api-v\d*.\d*.\d*$/'
+#      when: always

--- a/scripts/krectl/cmd_build.sh
+++ b/scripts/krectl/cmd_build.sh
@@ -57,7 +57,8 @@ build_docker_images() {
   build_image kre-k8s-manager admin/k8s-manager
 
   if [ "$SKIP_FRONTEND_BUILD" != "1" ]; then
-    docker run --rm -v `pwd`/admin/admin-ui:/app -w /app node:14 sh -c 'yarn install && yarn run build'
+    yarn --cwd admin/admin-ui install
+    yarn --cwd admin/admin-ui run build
     build_image kre-admin-ui admin/admin-ui
   fi
 

--- a/scripts/krectl/cmd_build.sh
+++ b/scripts/krectl/cmd_build.sh
@@ -57,6 +57,7 @@ build_docker_images() {
   build_image kre-k8s-manager admin/k8s-manager
 
   if [ "$SKIP_FRONTEND_BUILD" != "1" ]; then
+    docker run --rm -v `pwd`/admin/admin-ui:/app -w /app node:14 sh -c 'yarn install && yarn run build'
     build_image kre-admin-ui admin/admin-ui
   fi
 


### PR DESCRIPTION
In order to build the KRE Docker images with support of AMD64 and ARM64 we need to build for both architectures. The easiest way looks like is using docker buildx.