### PR TITLE
fix: volume claims  names per runtime

### DIFF
--- a/runtime/k8s-runtime-operator/helm-charts/kre-chart/templates/chronograf/deployment.yml
+++ b/runtime/k8s-runtime-operator/helm-charts/kre-chart/templates/chronograf/deployment.yml
@@ -38,7 +38,7 @@ spec:
       volumes:
         - name: data
           persistentVolumeClaim:
-            claimName: chronograf-pvc
+            claimName: {{ .Release.Name }}-chronograf-pvc
         - name: config
           configMap:
             name: chronograf-config

--- a/runtime/k8s-runtime-operator/helm-charts/kre-chart/templates/chronograf/pvc.yml
+++ b/runtime/k8s-runtime-operator/helm-charts/kre-chart/templates/chronograf/pvc.yml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: chronograf-pvc
+  name: {{ .Release.Name }}-chronograf-pvc
   labels:
     app: chronograf
   annotations:

--- a/runtime/k8s-runtime-operator/helm-charts/kre-chart/templates/minio/statefulset.yaml
+++ b/runtime/k8s-runtime-operator/helm-charts/kre-chart/templates/minio/statefulset.yaml
@@ -32,7 +32,7 @@ spec:
             - secretRef:
                 name: kre-minio-secret
           volumeMounts:
-            - name: kre-minio-pvc
+            - name: {{ .Release.Name }}-kre-minio-pvc
               mountPath: "/data"
           ports:
             - containerPort: 9000
@@ -50,7 +50,7 @@ spec:
             periodSeconds: 10
   volumeClaimTemplates:
     - metadata:
-        name: kre-minio-pvc
+        name: {{ .Release.Name }}-kre-minio-pvc
       spec:
         accessModes:
           - ReadWriteMany


### PR DESCRIPTION
These changes will update the Runtime Operator adding the runtime name to the PVC name, solving the issue of local deployment on Minikube with hostPath provisioner where create the same path for those volumes within the host.
Close #245 