### PR TITLE
fix(admin-ui): entrypoint url tooltip now grows with entrypoint length

### DIFF
--- a/admin/admin-ui/src/Pages/Version/pages/Status/components/Tooltip/EntrypointTooltipContent.module.scss
+++ b/admin/admin-ui/src/Pages/Version/pages/Status/components/Tooltip/EntrypointTooltipContent.module.scss
@@ -7,22 +7,9 @@
   display: flex;
   flex-direction: row;
   align-items: baseline;
+  justify-content: space-between;
 
-  input {
-    @include font-body;
-    color: font-color(light);
-
-    width: -webkit-fill-available;
-    background: none;
-    border: none;
-    outline: none;
+  .address {
+    align-self: center;
   }
-  div {
-    margin: 0 (2 * $grid-unit) 0 auto;
-    cursor: pointer;
-  }
-}
-
-.copyButton svg {
-  margin-right: -$grid-unit;
 }

--- a/admin/admin-ui/src/Pages/Version/pages/Status/components/Tooltip/EntrypointTooltipContent.tsx
+++ b/admin/admin-ui/src/Pages/Version/pages/Status/components/Tooltip/EntrypointTooltipContent.tsx
@@ -1,30 +1,19 @@
-import React, { useRef } from 'react';
-
 import { Button } from 'kwc';
 import IconCopy from '@material-ui/icons/FileCopy';
+import React from 'react';
+import { copyToClipboard } from 'Utils/clipboard';
 import styles from './EntrypointTooltipContent.module.scss';
 
 type InputProps = {
   entrypointAddress: string;
 };
 export function EntrypointTooltipContent({ entrypointAddress }: InputProps) {
-  const inputRef = useRef<HTMLInputElement>(null);
-
-  function onCopyToClipboard() {
-    if (inputRef.current !== null) {
-      inputRef.current.select();
-      inputRef.current.setSelectionRange(0, 99999);
-
-      document.execCommand('copy');
-    }
-  }
-
   return (
     <div className={styles.wrapper}>
-      <input type="text" value={entrypointAddress} ref={inputRef} readOnly />
+      <span className={styles.address}>{entrypointAddress}</span>
       <Button
         label=""
-        onClick={onCopyToClipboard}
+        onClick={() => copyToClipboard(entrypointAddress)}
         Icon={IconCopy}
         className={styles.copyButton}
       />

--- a/admin/admin-ui/src/Pages/Version/pages/Status/components/Tooltip/Tooltip.module.scss
+++ b/admin/admin-ui/src/Pages/Version/pages/Status/components/Tooltip/Tooltip.module.scss
@@ -3,7 +3,6 @@
 @import 'Styles/shadows';
 @import 'Styles/colors';
 
-$width: $grid-unit * 55;
 $padding-y: 14px;
 $separation: 21px;
 $color-line: palette(base, 800);
@@ -28,7 +27,8 @@ $color-bg: $bg-color-dark;
   @include shadow(2);
 
   border-radius: $grid-unit / 2;
-  width: $width;
+  min-width: $grid-unit * 55;
+  max-width: $grid-unit * 75;
   padding: 11px $padding-y;
   background-color: $color-bg;
   border-left: solid 3px $color-ok;


### PR DESCRIPTION
Short URL:
![image](https://user-images.githubusercontent.com/23691885/92392210-3775c780-f11e-11ea-95ec-b9065255c940.png)

Medium URL:
![image](https://user-images.githubusercontent.com/23691885/92392267-4b212e00-f11e-11ea-86b2-d3423f4cf221.png)

Large URL:
![image](https://user-images.githubusercontent.com/23691885/92392363-73109180-f11e-11ea-9a25-0d1f8ef6e6aa.png)
