### PR TITLE
feat: set the runtime id on creation

### DIFF
--- a/admin/admin-api/adapter/gql/generated.go
+++ b/admin/admin-api/adapter/gql/generated.go
@@ -1304,6 +1304,7 @@ type Subscription {
 }
 
 input CreateRuntimeInput {
+  id: String!
   name: String!
   description: String!
 }
@@ -7054,6 +7055,12 @@ func (ec *executionContext) unmarshalInputCreateRuntimeInput(ctx context.Context
 
 	for k, v := range asMap {
 		switch k {
+		case "id":
+			var err error
+			it.ID, err = ec.unmarshalNString2string(ctx, v)
+			if err != nil {
+				return it, err
+			}
 		case "name":
 			var err error
 			it.Name, err = ec.unmarshalNString2string(ctx, v)

--- a/admin/admin-api/adapter/gql/models.go
+++ b/admin/admin-api/adapter/gql/models.go
@@ -13,6 +13,7 @@ type ConfigurationVariablesInput struct {
 }
 
 type CreateRuntimeInput struct {
+	ID          string `json:"id"`
 	Name        string `json:"name"`
 	Description string `json:"description"`
 }

--- a/admin/admin-api/adapter/gql/resolver.go
+++ b/admin/admin-api/adapter/gql/resolver.go
@@ -69,7 +69,12 @@ func NewGraphQLResolver(
 
 func (r *mutationResolver) CreateRuntime(ctx context.Context, input CreateRuntimeInput) (*entity.Runtime, error) {
 	loggedUserID := ctx.Value("userID").(string)
-	runtime, onRuntimeStartedChannel, err := r.runtimeInteractor.CreateRuntime(ctx, loggedUserID, input.Name, input.Description)
+
+	runtime, onRuntimeStartedChannel, err := r.runtimeInteractor.CreateRuntime(ctx, loggedUserID, input.ID, input.Name, input.Description)
+	if err != nil {
+		r.logger.Error("Error creating runtime: " + err.Error())
+		return nil, err
+	}
 
 	go func() {
 		runtime := <-onRuntimeStartedChannel
@@ -78,11 +83,6 @@ func (r *mutationResolver) CreateRuntime(ctx context.Context, input CreateRuntim
 			r <- runtime
 		}
 	}()
-
-	if err != nil {
-		r.logger.Error("Error creating runtime: " + err.Error())
-		return nil, err
-	}
 
 	return runtime, nil
 }

--- a/admin/admin-api/adapter/repository/mongodb/runtime.go
+++ b/admin/admin-api/adapter/repository/mongodb/runtime.go
@@ -5,7 +5,6 @@ import (
 	"time"
 
 	"go.mongodb.org/mongo-driver/bson"
-	"go.mongodb.org/mongo-driver/bson/primitive"
 	"go.mongodb.org/mongo-driver/mongo"
 
 	"github.com/konstellation-io/kre/admin/admin-api/adapter/config"
@@ -30,16 +29,14 @@ func NewRuntimeRepoMongoDB(cfg *config.Config, logger logging.Logger, client *mo
 }
 
 func (r *RuntimeRepoMongoDB) Create(ctx context.Context, runtime *entity.Runtime) (*entity.Runtime, error) {
-	runtime.ID = primitive.NewObjectID().Hex()
 	runtime.CreationDate = time.Now().UTC()
 	runtime.Status = entity.RuntimeStatusCreating
 
-	res, err := r.collection.InsertOne(ctx, runtime)
+	_, err := r.collection.InsertOne(ctx, runtime)
 	if err != nil {
 		return nil, err
 	}
 
-	runtime.ID = res.InsertedID.(string)
 	return runtime, nil
 }
 
@@ -83,7 +80,7 @@ func (r *RuntimeRepoMongoDB) GetByID(ctx context.Context, runtimeID string) (*en
 
 	err := r.collection.FindOne(ctx, filter).Decode(runtime)
 	if err == mongo.ErrNoDocuments {
-		return runtime, usecase.ErrRuntimeNotFound
+		return nil, usecase.ErrRuntimeNotFound
 	}
 
 	return runtime, err

--- a/admin/admin-api/adapter/service/runtime.go
+++ b/admin/admin-api/adapter/service/runtime.go
@@ -34,6 +34,8 @@ func NewK8sRuntimeClient(cfg *config.Config, logger logging.Logger) (*K8sRuntime
 }
 
 func (k *K8sRuntimeClient) Create(ctx context.Context, runtime *entity.Runtime) (string, error) {
+	k.logger.Infof("Creating the runtime \"%s\" (%s) in k8s...", runtime.Name, runtime.GetNamespace())
+
 	req := runtimepb.Request{
 		Runtime: &runtimepb.Runtime{
 			Name:      runtime.Name,

--- a/admin/admin-api/domain/usecase/runtime_test.go
+++ b/admin/admin-api/domain/usecase/runtime_test.go
@@ -142,7 +142,7 @@ func TestCreateRuntime(t *testing.T) {
 
 	s.mocks.accessControl.EXPECT().CheckPermission(userID, auth.ResRuntime, auth.ActEdit).Return(nil)
 
-	runtime, createdRuntimeChannel, err := s.runtimeInteractor.CreateRuntime(ctx, userID, name, description)
+	runtime, createdRuntimeChannel, err := s.runtimeInteractor.CreateRuntime(ctx, userID, "", name, description)
 	require.Nil(t, err)
 	require.Equal(t, expectedRuntime, runtime)
 

--- a/admin/admin-api/schema.graphql
+++ b/admin/admin-api/schema.graphql
@@ -59,6 +59,7 @@ type Subscription {
 }
 
 input CreateRuntimeInput {
+  id: String!
   name: String!
   description: String!
 }

--- a/admin/admin-ui/package.json
+++ b/admin/admin-ui/package.json
@@ -27,7 +27,7 @@
     "enzyme-to-json": "3.5.0",
     "graphql": "14.6.0",
     "graphql.macro": "github:mgs95/graphql.macro#build",
-    "kwc": "1.0.0",
+    "kwc": "1.1.0",
     "lodash": "4.17.19",
     "lottie-web": "5.7.0",
     "markdown-navbar": "1.4.2",

--- a/admin/admin-ui/src/Graphql/types/globalTypes.ts
+++ b/admin/admin-ui/src/Graphql/types/globalTypes.ts
@@ -56,9 +56,9 @@ export enum UserActivityType {
 }
 
 export enum VersionStatus {
-  PUBLISHED = 'PUBLISHED',
-  CREATING = 'CREATING',
   CREATED = 'CREATED',
+  CREATING = 'CREATING',
+  PUBLISHED = 'PUBLISHED',
   STARTED = 'STARTED',
   STARTING = 'STARTING',
   STOPPED = 'STOPPED',
@@ -71,6 +71,7 @@ export interface ConfigurationVariablesInput {
 }
 
 export interface CreateRuntimeInput {
+  id: string;
   name: string;
   description: string;
 }

--- a/admin/admin-ui/src/Pages/AddRuntime/AddRuntime.tsx
+++ b/admin/admin-ui/src/Pages/AddRuntime/AddRuntime.tsx
@@ -121,7 +121,6 @@ function AddRuntime() {
   }
 
   function onSubmit(formData: any) {
-    console.log(formData);
     addRuntime(mutationPayloadHelper(formData));
   }
 

--- a/admin/admin-ui/yarn.lock
+++ b/admin/admin-ui/yarn.lock
@@ -6796,12 +6796,12 @@ enzyme-matchers@^7.1.1:
     deep-equal-ident "^1.1.1"
 
 enzyme-shallow-equal@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/enzyme-shallow-equal/-/enzyme-shallow-equal-1.0.1.tgz#7afe03db3801c9b76de8440694096412a8d9d49e"
-  integrity sha512-hGA3i1so8OrYOZSM9whlkNmVHOicJpsjgTzC+wn2JMJXhq1oO4kA4bJ5MsfzSIcC71aLDKzJ6gZpIxrqt3QTAQ==
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/enzyme-shallow-equal/-/enzyme-shallow-equal-1.0.4.tgz#b9256cb25a5f430f9bfe073a84808c1d74fced2e"
+  integrity sha512-MttIwB8kKxypwHvRynuC3ahyNc+cFbR8mjVIltnmzQ0uKGqmsfO4bfBuLxb0beLNPhjblUEYvEbsg+VSygvF1Q==
   dependencies:
     has "^1.0.3"
-    object-is "^1.0.2"
+    object-is "^1.1.2"
 
 enzyme-to-json@3.5.0:
   version "3.5.0"
@@ -10704,16 +10704,17 @@ kleur@^3.0.3:
   resolved "https://registry.yarnpkg.com/kleur/-/kleur-3.0.3.tgz#a79c9ecc86ee1ce3fa6206d1216c501f147fc07e"
   integrity sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==
 
-kwc@1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/kwc/-/kwc-1.0.0.tgz#ea38eec78c9285100360a158b127c20394aedd8c"
-  integrity sha512-PYQ/33htCuAdwOLEPc/CrnKKNSzcI2X3lyxH0qNMszmI6XKK6isnSmMBMDGNLUlRKF6/rEQTlTbl3IEBAlVX5w==
+kwc@1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/kwc/-/kwc-1.1.0.tgz#e2b66fc6ab3cf4dd827b801b6fc0e24188140ac7"
+  integrity sha512-XQ3O5wu+657RdC0VuutoHroI6zi+XHNHLw/L0zHuQuc3L8sO2BAOf8WAUWTHxhs82WW4PZ4n8zH2Yn8SlAwXEw==
   dependencies:
     "@material-ui/core" "^4.11.0"
     "@material-ui/icons" "^4.9.1"
     lodash "^4.17.19"
     react-dates "^21.8.0"
     react-router-dom "^5.2.0"
+    validator "^13.1.1"
 
 last-call-webpack-plugin@^3.0.0:
   version "3.0.0"
@@ -11501,7 +11502,7 @@ lodash.xorby@^4.7.0:
   resolved "https://registry.yarnpkg.com/lodash.xorby/-/lodash.xorby-4.7.0.tgz#9c19a6f9f063a6eb53dd03c1b6871799801463d7"
   integrity sha1-nBmm+fBjputT3QPBtocXmYAUY9c=
 
-lodash@4.17.19, "lodash@>=3.5 <5", lodash@^4, lodash@^4.0.0, lodash@^4.1.1, lodash@^4.15.0, lodash@^4.17.11, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.4, lodash@^4.17.5, lodash@~4.17.12:
+lodash@4.17.19, "lodash@>=3.5 <5", lodash@^4, lodash@^4.0.0, lodash@^4.15.0, lodash@^4.17.11, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.4, lodash@^4.17.5, lodash@~4.17.12:
   version "4.17.19"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.19.tgz#e48ddedbe30b3321783c5b4301fbd353bc1e4a4b"
   integrity sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==
@@ -11510,6 +11511,11 @@ lodash@^3.3.1:
   version "3.10.1"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-3.10.1.tgz#5bf45e8e49ba4189e17d482789dfd15bd140b7b6"
   integrity sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=
+
+lodash@^4.1.1:
+  version "4.17.20"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.20.tgz#b44a9b6297bcb698f1c51a3545a2b3b368d59c52"
+  integrity sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==
 
 log-symbols@^1.0.2:
   version "1.0.2"
@@ -12796,7 +12802,7 @@ object-inspect@^1.6.0, object-inspect@^1.7.0:
   resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.8.0.tgz#df807e5ecf53a609cc6bfe93eac3cc7be5b3a9d0"
   integrity sha512-jLdtEOB112fORuypAyl/50VRVIBIdVQOSUUGQHzJ4xBSbit81zRarz7GThkEFZy1RceYrWYcPcBFPQwHyAc1gA==
 
-object-is@^1.0.1, object-is@^1.0.2, object-is@^1.1.2:
+object-is@^1.0.1, object-is@^1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/object-is/-/object-is-1.1.2.tgz#c5d2e87ff9e119f78b7a088441519e2eec1573b6"
   integrity sha512-5lHCz+0uufF6wZ7CRFWJN3hp8Jqblpgve06U5CMQ3f//6iDjPr2PEo9MWCjEssDsa+UZEL4PkFpr+BMop6aKzQ==
@@ -17837,6 +17843,11 @@ validate-npm-package-name@^3.0.0, validate-npm-package-name@~3.0.0:
   integrity sha1-X6kS2B630MdK/BQN5zF/DKffQ34=
   dependencies:
     builtins "^1.0.3"
+
+validator@^13.1.1:
+  version "13.1.1"
+  resolved "https://registry.yarnpkg.com/validator/-/validator-13.1.1.tgz#f8811368473d2173a9d8611572b58c5783f223bf"
+  integrity sha512-8GfPiwzzRoWTg7OV1zva1KvrSemuMkv07MA9TTl91hfhe+wKrsrgVN4H2QSFd/U/FhiU3iWPYVgvbsOGwhyFWw==
 
 value-equal@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
- The runtime ID is configurable in the creation process
- Remove all restrictions from the name property (lowercase, minlength=20, etc...)
- Validate Runtime fields on the server side
- Check if the Runtime already exists before creating