### PR TITLE
WIP: add middleware to check JWT token and endpoint to signIn with API Token.

### DIFF
--- a/admin/admin-api/adapter/repository/mongodb/user.go
+++ b/admin/admin-api/adapter/repository/mongodb/user.go
@@ -103,6 +103,18 @@ func (r *UserRepoMongoDB) GetManyByEmail(ctx context.Context, email string) ([]*
 	return users, nil
 }
 
+func (r *UserRepoMongoDB) GetByApiToken(apiToken string) (*entity.User, error) {
+	user := &entity.User{}
+	filter := bson.D{{"apiToken", apiToken}}
+
+	err := r.collection.FindOne(context.Background(), filter).Decode(user)
+	if err == mongo.ErrNoDocuments {
+		return user, usecase.ErrInvalidApiToken
+	}
+
+	return user, err
+}
+
 func (r *UserRepoMongoDB) GetByID(userID string) (*entity.User, error) {
 	user := &entity.User{}
 	filter := bson.D{{"_id", userID}}

--- a/admin/admin-api/domain/repository/user.go
+++ b/admin/admin-api/domain/repository/user.go
@@ -19,6 +19,8 @@ type UserRepo interface {
 
 	GetByID(userID string) (*entity.User, error)
 
+	GetByApiToken(apiToken string) (*entity.User, error)
+
 	GetByIDs(keys []string) ([]*entity.User, error)
 
 	GetAll(ctx context.Context, returnDeleted bool) ([]*entity.User, error)

--- a/admin/admin-api/domain/usecase/auth.go
+++ b/admin/admin-api/domain/usecase/auth.go
@@ -61,6 +61,8 @@ var (
 	ErrVerificationCodeNotFound = errors.New("error the verification not found")
 	// ErrExpiredVerificationCode error
 	ErrExpiredVerificationCode = errors.New("error the verification code code is expired")
+	// ErrInvalidApiToken error
+	ErrInvalidApiToken = errors.New("error invalid API Token")
 	// ErrUserNotAllowed error
 	ErrUserNotAllowed = errors.New("error email address not allowed")
 	// ErrInvalidSession error
@@ -193,6 +195,16 @@ func (a *AuthInteractor) Logout(userID, token string) error {
 
 func (a *AuthInteractor) CreateSession(session entity.Session) error {
 	return a.sessionRepo.Create(session)
+}
+
+func (a *AuthInteractor) CheckApiToken(apiToken string) (string, error) {
+	user, err := a.userRepo.GetByApiToken(apiToken)
+	if err != nil {
+		a.logger.Errorf("Error getting user with API Token '%s': %s", apiToken, err)
+		return "", err
+	}
+
+	return user.ID, nil
 }
 
 func (a *AuthInteractor) CheckSessionIsActive(token string) error {


### PR DESCRIPTION
Assuming users have `apiToken` in MongoDB this PR add following features: 

- skip JWT token validation if `Authorization` header is present. (only for `/graphql` endpoint)
- new endpoint to perfom signIn with user's API Token


Related to https://github.com/konstellation-io/kli/issues/1

