### PR TITLE
fix: resource metrics not working

### DIFF
--- a/admin/k8s-manager/prometheus/resourcemetrics/manager.go
+++ b/admin/k8s-manager/prometheus/resourcemetrics/manager.go
@@ -125,9 +125,9 @@ func (m *Manager) prometheusQuery(
 	cpuQuery := fmt.Sprintf(`sum (
 		max(kube_pod_labels{label_version_name='%s'}) by(label_version_name, pod) * on (pod) group_right(label_version_name)
 		label_replace(
-			 sum by (pod_name)(
-				  rate(container_cpu_usage_seconds_total{namespace='%s', container_name!="POD",container_name!=""}[5m])*1000
-			 ), 'pod', '$1', 'pod_name', '(.+)'
+			 sum by (pod)(
+				  rate(container_cpu_usage_seconds_total{namespace='%s', container!="POD",container!=""}[5m])*1000
+			 ), 'pod', '$1', 'pod', '(.+)'
 		)
 	 ) by (label_version_name)`, versionName, namespace)
 
@@ -144,9 +144,9 @@ func (m *Manager) prometheusQuery(
 	memQuery := fmt.Sprintf(`sum (
 		max(kube_pod_labels{label_version_name='%s'}) by(label_version_name, pod) * on (pod) group_right(label_version_name)
 		label_replace(
-			 sum by (pod_name)(
-				  container_memory_working_set_bytes{namespace='%s', container_name!="POD",container_name!=""}
-			 ), 'pod', '$1', 'pod_name', '(.+)'
+			 sum by (pod)(
+				  container_memory_working_set_bytes{namespace='%s', container!="POD",container!=""}
+			 ), 'pod', '$1', 'pod', '(.+)'
 		)
 	 ) by (label_version_name)`, versionName, namespace)
 

--- a/admin/k8s-manager/service/resourcemetrics.go
+++ b/admin/k8s-manager/service/resourcemetrics.go
@@ -37,11 +37,11 @@ func (r *ResourceMetricsService) GetVersion(
 		VersionRequest: *req,
 	}
 
-	r.logger.Infof("Getting metrics for version %v", input.VersionRequest)
+	r.logger.Debugf("Getting metrics for version: %s", input.VersionRequest.String())
 
 	metrics, err := r.manager.GetVersionResourceMetrics(input)
 	if err != nil {
-		r.logger.Errorf("Error getting metrics: %v", err)
+		r.logger.Errorf("Error getting metrics: %s", err)
 		return nil, err
 	}
 


### PR DESCRIPTION
To solve this issue we have changed the "pod_name", "container_name" to "pod", "container" field names in the prometheus query. For more info:
https://github.com/kubernetes/kubernetes/issues/66790

(cherry picked from commit b64e7738f782edabb440dc347945c4aa07f4e668)