### PR TITLE
add SimpleloggerInterface and NewWithWriter() to print output other than os.Stdout.

### DIFF
--- a/libs/simplelogger/simplelogger.go
+++ b/libs/simplelogger/simplelogger.go
@@ -2,6 +2,8 @@ package simplelogger
 
 import (
 	"fmt"
+	"io"
+	"os"
 	"regexp"
 	"time"
 )
@@ -24,14 +26,35 @@ var levelNames = []string{
 
 var lineBreakRE = regexp.MustCompile(`\r?\n`)
 
+type SimpleLoggerInterface interface {
+	Debug(msg string)
+	Info(msg string)
+	Warn(msg string)
+	Error(msg string)
+	Debugf(format string, a ...interface{})
+	Infof(format string, a ...interface{})
+	Warnf(format string, a ...interface{})
+	Errorf(format string, a ...interface{})
+}
+
 type SimpleLogger struct {
-	level LogLevel
+	level  LogLevel
+	writer io.Writer
 }
 
 // New creates a new SimpleLogger instance.
 func New(level LogLevel) *SimpleLogger {
 	return &SimpleLogger{
-		level: level,
+		level:  level,
+		writer: os.Stdout,
+	}
+}
+
+// New creates a new SimpleLogger instance.
+func NewWithWriter(level LogLevel, writer io.Writer) *SimpleLogger {
+	return &SimpleLogger{
+		level,
+		writer,
 	}
 }
 
@@ -41,7 +64,7 @@ func (l *SimpleLogger) printLog(level LogLevel, msg string) {
 	}
 
 	t := time.Now().Format(time.RFC3339Nano)
-	fmt.Printf("%s %s %s\n", t, levelNames[level], lineBreakRE.ReplaceAllLiteralString(msg, " "))
+	_, _ = fmt.Fprintf(l.writer, "%s %s %s\n", t, levelNames[level], lineBreakRE.ReplaceAllLiteralString(msg, " "))
 }
 
 func (l *SimpleLogger) Debug(msg string) {

--- a/libs/simplelogger/simplelogger_test.go
+++ b/libs/simplelogger/simplelogger_test.go
@@ -1,6 +1,7 @@
 package simplelogger_test
 
 import (
+	"bytes"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -42,138 +43,164 @@ func assertLoggedMsg(t *testing.T, output, level, msg string) {
 	}
 }
 
+func TestLoggerWithWriter(t *testing.T) {
+	msg := "test message"
+	b := bytes.NewBufferString("")
+
+	logger := simplelogger.NewWithWriter(simplelogger.LevelDebug, b)
+	logger.Error(msg)
+
+	assertLoggedMsg(t, b.String(), "ERROR", msg)
+}
+
 func TestLevelDebugLogger(t *testing.T) {
-	logger := simplelogger.New(simplelogger.LevelDebug)
 	msg := "test message"
 
 	output := captureOutput(func() {
+		logger := simplelogger.New(simplelogger.LevelDebug)
+		msg := "test message"
 		logger.Error(msg)
 	})
 	assertLoggedMsg(t, output, "ERROR", msg)
 
 	output = captureOutput(func() {
+		logger := simplelogger.New(simplelogger.LevelDebug)
 		logger.Warn(msg)
 	})
 	assertLoggedMsg(t, output, "WARN", msg)
 
 	output = captureOutput(func() {
+		logger := simplelogger.New(simplelogger.LevelDebug)
 		logger.Info(msg)
 	})
 	assertLoggedMsg(t, output, "INFO", msg)
 
 	output = captureOutput(func() {
+		logger := simplelogger.New(simplelogger.LevelDebug)
 		logger.Debug(msg)
 	})
 	assertLoggedMsg(t, output, "DEBUG", msg)
 }
 
 func TestLevelInfoLogger(t *testing.T) {
-	logger := simplelogger.New(simplelogger.LevelInfo)
 	msg := "test message"
 
 	output := captureOutput(func() {
+		logger := simplelogger.New(simplelogger.LevelInfo)
 		logger.Error(msg)
 	})
 	assertLoggedMsg(t, output, "ERROR", msg)
 
 	output = captureOutput(func() {
+		logger := simplelogger.New(simplelogger.LevelInfo)
 		logger.Warn(msg)
 	})
 	assertLoggedMsg(t, output, "WARN", msg)
 
 	output = captureOutput(func() {
+		logger := simplelogger.New(simplelogger.LevelInfo)
 		logger.Info(msg)
 	})
 	assertLoggedMsg(t, output, "INFO", msg)
 
 	output = captureOutput(func() {
+		logger := simplelogger.New(simplelogger.LevelInfo)
 		logger.Debug(msg)
 	})
 	assertEqual(t, output, "")
 }
 
 func TestLevelWarnLogger(t *testing.T) {
-	logger := simplelogger.New(simplelogger.LevelWarn)
 	msg := "test message"
 
 	output := captureOutput(func() {
+		logger := simplelogger.New(simplelogger.LevelWarn)
 		logger.Error(msg)
 	})
 	assertLoggedMsg(t, output, "ERROR", msg)
 
 	output = captureOutput(func() {
+		logger := simplelogger.New(simplelogger.LevelWarn)
 		logger.Warn(msg)
 	})
 	assertLoggedMsg(t, output, "WARN", msg)
 
 	output = captureOutput(func() {
+		logger := simplelogger.New(simplelogger.LevelWarn)
 		logger.Info(msg)
 	})
 	assertEqual(t, output, "")
 
 	output = captureOutput(func() {
+		logger := simplelogger.New(simplelogger.LevelWarn)
 		logger.Debug(msg)
 	})
 	assertEqual(t, output, "")
 }
 
 func TestLevelErrorLogger(t *testing.T) {
-	logger := simplelogger.New(simplelogger.LevelError)
 	msg := "test message"
 
 	output := captureOutput(func() {
+		logger := simplelogger.New(simplelogger.LevelError)
 		logger.Error(msg)
 	})
 	assertLoggedMsg(t, output, "ERROR", msg)
 
 	output = captureOutput(func() {
+		logger := simplelogger.New(simplelogger.LevelError)
 		logger.Warn(msg)
 	})
 	assertEqual(t, output, "")
 
 	output = captureOutput(func() {
+		logger := simplelogger.New(simplelogger.LevelError)
 		logger.Info(msg)
 	})
 	assertEqual(t, output, "")
 
 	output = captureOutput(func() {
+		logger := simplelogger.New(simplelogger.LevelError)
 		logger.Debug(msg)
 	})
 	assertEqual(t, output, "")
 }
 
 func TestLoggerWithFormatters(t *testing.T) {
-	logger := simplelogger.New(simplelogger.LevelDebug)
 	msg := "test formatted message: %s %s"
 	arg1 := "some value"
 	arg2 := "another value"
 
 	output := captureOutput(func() {
+		logger := simplelogger.New(simplelogger.LevelDebug)
 		logger.Errorf(msg, arg1, arg2)
 	})
 	assertLoggedMsg(t, output, "ERROR", fmt.Sprintf(msg, arg1, arg2))
 
 	output = captureOutput(func() {
+		logger := simplelogger.New(simplelogger.LevelDebug)
 		logger.Warnf(msg, arg1, arg2)
 	})
 	assertLoggedMsg(t, output, "WARN", fmt.Sprintf(msg, arg1, arg2))
 
 	output = captureOutput(func() {
+		logger := simplelogger.New(simplelogger.LevelDebug)
 		logger.Infof(msg, arg1, arg2)
 	})
 	assertLoggedMsg(t, output, "INFO", fmt.Sprintf(msg, arg1, arg2))
 
 	output = captureOutput(func() {
+		logger := simplelogger.New(simplelogger.LevelDebug)
 		logger.Debugf(msg, arg1, arg2)
 	})
 	assertLoggedMsg(t, output, "DEBUG", fmt.Sprintf(msg, arg1, arg2))
 }
 
 func TestLoggerWithLineBreaks(t *testing.T) {
-	logger := simplelogger.New(simplelogger.LevelDebug)
 	msg := "\ntest \nwith line breaks\n message\n"
 
 	output := captureOutput(func() {
+		logger := simplelogger.New(simplelogger.LevelDebug)
 		logger.Info(msg)
 	})
 	assertLoggedMsg(t, output, "INFO", " test  with line breaks  message ")


### PR DESCRIPTION
this PR is compatible with the current version, but adds an interface and the possibility to write to different output than `os.Stdout`.