### PR TITLE
fix acceptance tests, substituting versionId with versionName

### DIFF
--- a/tests/acceptance/features/Runtime_Version_Management.feature
+++ b/tests/acceptance/features/Runtime_Version_Management.feature
@@ -4,19 +4,19 @@ Feature: Runtime Version Management
 
   Scenario: Version publishing
     Given the API client has already logged in
-    And the version "5fbd2724f6f308a6b8c5ad90" status is "STARTED"
-    When the API client publish the version "5fbd2724f6f308a6b8c5ad90" sending "publish integration test" comment
-    Then the version "5fbd2724f6f308a6b8c5ad90" status is "PUBLISHED"
+    And the version "runtime-test-v1" status is "STARTED"
+    When the API client publish the version "runtime-test-v1" sending "publish integration test" comment
+    Then the version "runtime-test-v1" status is "PUBLISHED"
 
   Scenario: Version unpublishing
     Given the API client has already logged in
-    And the version "5fbd2724f6f308a6b8c5ad90" status is "PUBLISHED"
-    When the API client unpublish the version "5fbd2724f6f308a6b8c5ad90" sending "unpublish integration test" comment
-    Then the version "5fbd2724f6f308a6b8c5ad90" status is "STARTED"
+    And the version "runtime-test-v1" status is "PUBLISHED"
+    When the API client unpublish the version "runtime-test-v1" sending "unpublish integration test" comment
+    Then the version "runtime-test-v1" status is "STARTED"
 
   Scenario: Request to an entrypoint
     Given the API client has already logged in
-    And the version "5fbd2724f6f308a6b8c5ad90" status is "PUBLISHED"
-    When the API client calls to the workflow WorkflowTest at "entrypoint.kre-int-tests.kre-int.konstellation.io:443"
+    And the version "runtime-test-v1" status is "PUBLISHED"
+    When the API client calls to the workflow WorkflowTest at "entrypoint.kre-int.konstellation.io:443"
     Then the workflow response contains a property "go_runner_success" equal to "true"
     Then the workflow response contains a property "py_runner_success" equal to "true"

--- a/tests/acceptance/graphql/auth.go
+++ b/tests/acceptance/graphql/auth.go
@@ -7,7 +7,6 @@ import (
 	"log"
 	"net/http"
 	"net/url"
-	"path"
 	"strconv"
 	"strings"
 	"time"
@@ -23,16 +22,14 @@ func (g *GQManager) SignIn() error {
 	data := url.Values{}
 	data.Add("apiToken", g.cfg.APIToken)
 
-	u, err := url.Parse(g.cfg.APIBaseURL)
+	signInURL, err := getAPIURL(g.cfg.APIBaseURL, "/api/v1/auth/token/signin")
+
 	if err != nil {
 		return err
 	}
-	u.Path = path.Join(u.Path, "/api/v1/auth/token/signin")
-	signInURL := u.String()
 
 	log.Printf("Getting valid access token from %s...", signInURL)
 
-	//nolint:gosec
 	ctx, cancel := context.WithTimeout(context.Background(), signInTimeout)
 	defer cancel()
 

--- a/tests/acceptance/graphql/auth.go
+++ b/tests/acceptance/graphql/auth.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"net/http"
 	"net/url"
+	"path"
 	"strconv"
 	"strings"
 	"time"
@@ -22,7 +23,13 @@ func (g *GQManager) SignIn() error {
 	data := url.Values{}
 	data.Add("apiToken", g.cfg.APIToken)
 
-	signInURL := fmt.Sprintf("%s/api/v1/auth/token/signin", g.cfg.APIBaseURL)
+	u, err := url.Parse(g.cfg.APIBaseURL)
+	if err != nil {
+		return err
+	}
+	u.Path = path.Join(u.Path, "/api/v1/auth/token/signin")
+	signInURL := u.String()
+
 	log.Printf("Getting valid access token from %s...", signInURL)
 
 	//nolint:gosec

--- a/tests/acceptance/graphql/graphql.go
+++ b/tests/acceptance/graphql/graphql.go
@@ -22,13 +22,25 @@ type GQManager struct {
 	accessToken string
 }
 
+func getAPIURL(baseURL, pathURL string) (string, error) {
+	u, err := url.Parse(baseURL)
+
+	if err != nil {
+		return "", err
+	}
+
+	u.Path = path.Join(u.Path, pathURL)
+	fullURL := u.String()
+
+	return fullURL, nil
+}
+
 func NewGQManager(cfg config.Config) (*GQManager, error) {
-	u, err := url.Parse(cfg.APIBaseURL)
+	graphQLURL, err := getAPIURL(cfg.APIBaseURL, "/graphql")
+
 	if err != nil {
 		return nil, err
 	}
-	u.Path = path.Join(u.Path, "/graphql")
-	graphQLURL := u.String()
 
 	c := graphql.NewClient(graphQLURL)
 	c.Log = func(s string) { log.Println(s) }

--- a/tests/acceptance/graphql/graphql.go
+++ b/tests/acceptance/graphql/graphql.go
@@ -3,8 +3,9 @@ package graphql
 import (
 	"context"
 	"errors"
-	"fmt"
 	"log"
+	"net/url"
+	"path"
 	"time"
 
 	"github.com/machinebox/graphql"
@@ -21,15 +22,21 @@ type GQManager struct {
 	accessToken string
 }
 
-func NewGQManager(cfg config.Config) *GQManager {
-	graphQLURL := fmt.Sprintf("%s/graphql", cfg.APIBaseURL)
+func NewGQManager(cfg config.Config) (*GQManager, error) {
+	u, err := url.Parse(cfg.APIBaseURL)
+	if err != nil {
+		return nil, err
+	}
+	u.Path = path.Join(u.Path, "/graphql")
+	graphQLURL := u.String()
+
 	c := graphql.NewClient(graphQLURL)
 	c.Log = func(s string) { log.Println(s) }
 
 	return &GQManager{
 		cfg:    cfg,
 		client: c,
-	}
+	}, nil
 }
 
 func (g GQManager) makeRequest(query string, respData interface{}, vars map[string]interface{}) error {

--- a/tests/acceptance/graphql/mutation_version_publishing.go
+++ b/tests/acceptance/graphql/mutation_version_publishing.go
@@ -37,10 +37,10 @@ type versionUnpublishResponse struct {
 	}
 }
 
-func (g GQManager) VersionPublish(versionID, comment string) error {
+func (g GQManager) VersionPublish(versionName, comment string) error {
 	respData := versionPublishResponse{}
 
-	err := g.versionPublishing(versionPublish, &respData, versionID, comment)
+	err := g.versionPublishing(versionPublish, &respData, versionName, comment)
 	if err != nil {
 		return err
 	}
@@ -55,10 +55,10 @@ func (g GQManager) VersionPublish(versionID, comment string) error {
 	return nil
 }
 
-func (g GQManager) VersionUnpublish(versionID, comment string) error {
+func (g GQManager) VersionUnpublish(versionName, comment string) error {
 	respData := versionUnpublishResponse{}
 
-	err := g.versionPublishing(versionUnpublish, &respData, versionID, comment)
+	err := g.versionPublishing(versionUnpublish, &respData, versionName, comment)
 	if err != nil {
 		return err
 	}
@@ -73,9 +73,9 @@ func (g GQManager) VersionUnpublish(versionID, comment string) error {
 	return nil
 }
 
-func (g GQManager) versionPublishing(query string, respData interface{}, versionID, comment string) error {
+func (g GQManager) versionPublishing(query string, respData interface{}, versionName, comment string) error {
 	vars := map[string]interface{}{
-		"input": map[string]string{"versionId": versionID, "comment": comment},
+		"input": map[string]string{"versionName": versionName, "comment": comment},
 	}
 
 	err := g.makeRequest(query, &respData, vars)

--- a/tests/acceptance/graphql/query_version.go
+++ b/tests/acceptance/graphql/query_version.go
@@ -1,9 +1,9 @@
 package graphql
 
 const queryVersion = `
-	query FetchVersion($id: ID!) {
-		version(id: $id) {
-			id
+	query FetchVersion($name: String!) {
+		version(name: $name) {
+			name
 			status
 		}
 	}
@@ -11,16 +11,16 @@ const queryVersion = `
 
 type VersionResponse struct {
 	Version struct {
-		ID     string
+		Name   string
 		Status string
 	}
 }
 
-func (g GQManager) GetVersionStatus(versionID string) (string, error) {
+func (g GQManager) GetVersionStatus(versionName string) (string, error) {
 	var respData VersionResponse
 
 	vars := map[string]interface{}{
-		"id": versionID,
+		"name": versionName,
 	}
 
 	err := g.makeRequest(queryVersion, &respData, vars)

--- a/tests/acceptance/main_test.go
+++ b/tests/acceptance/main_test.go
@@ -25,7 +25,7 @@ func TestMain(m *testing.M) {
 
 	testRunner, err := integrationtests.NewTestRunner()
 	if err != nil {
-		log.Fatalf("unexpected error with integration tests runner: %p \n", err)
+		log.Fatalf("unexpected error with integration tests runner: %s", err)
 	}
 
 	status := godog.TestSuite{

--- a/tests/acceptance/main_test.go
+++ b/tests/acceptance/main_test.go
@@ -25,8 +25,7 @@ func TestMain(m *testing.M) {
 
 	testRunner, err := integrationtests.NewTestRunner()
 	if err != nil {
-		log.Println("The unittests URL is invalid")
-		os.Exit(1)
+		log.Fatalf("unexpected error with integration tests runner: %p \n", err)
 	}
 
 	status := godog.TestSuite{

--- a/tests/acceptance/main_test.go
+++ b/tests/acceptance/main_test.go
@@ -2,6 +2,7 @@ package integrationtests_test
 
 import (
 	"flag"
+	"log"
 	"os"
 	"testing"
 
@@ -22,7 +23,11 @@ func TestMain(m *testing.M) {
 	flag.Parse()
 	opts.Paths = flag.Args()
 
-	testRunner := integrationtests.NewTestRunner()
+	testRunner, err := integrationtests.NewTestRunner()
+	if err != nil {
+		log.Println("The unittests URL is invalid")
+		os.Exit(1)
+	}
 
 	status := godog.TestSuite{
 		Name: "godogs",

--- a/tests/acceptance/runner.go
+++ b/tests/acceptance/runner.go
@@ -13,6 +13,7 @@ type TestRunner struct {
 func NewTestRunner() (TestRunner, error) {
 	cfg := config.NewConfig()
 	gqManager, err := graphql.NewGQManager(cfg)
+
 	if err != nil {
 		return TestRunner{}, err
 	}

--- a/tests/acceptance/runner.go
+++ b/tests/acceptance/runner.go
@@ -10,14 +10,17 @@ type TestRunner struct {
 	State     map[string]interface{}
 }
 
-func NewTestRunner() TestRunner {
+func NewTestRunner() (TestRunner, error) {
 	cfg := config.NewConfig()
-	gqManager := graphql.NewGQManager(cfg)
+	gqManager, err := graphql.NewGQManager(cfg)
+	if err != nil {
+		return TestRunner{}, err
+	}
 
 	return TestRunner{
 		gqManager: gqManager,
 		State:     map[string]interface{}{},
-	}
+	}, nil
 }
 
 func (r *TestRunner) Reset() {

--- a/tests/acceptance/version_feature.go
+++ b/tests/acceptance/version_feature.go
@@ -17,17 +17,17 @@ import (
 
 const CallTimeout = 10
 
-func (r *TestRunner) theVersionStatusIs(versionID, expectedStatus string) error {
-	status, err := r.gqManager.GetVersionStatus(versionID)
+func (r *TestRunner) theVersionStatusIs(versionName, expectedStatus string) error {
+	status, err := r.gqManager.GetVersionStatus(versionName)
 	if err != nil {
 		return err
 	}
 
 	if expectedStatus != status {
 		if status == entity.VersionStatusPublished && expectedStatus == entity.VersionStatusStarted {
-			return r.gqManager.VersionUnpublish(versionID, "set to expected status")
+			return r.gqManager.VersionUnpublish(versionName, "set to expected status")
 		} else if status == entity.VersionStatusStarted && expectedStatus == entity.VersionStatusPublished {
-			return r.gqManager.VersionPublish(versionID, "set to expected status")
+			return r.gqManager.VersionPublish(versionName, "set to expected status")
 		} else {
 			// nolint:goerr113
 			return fmt.Errorf("the version status is %s and should be %s", status, expectedStatus)
@@ -37,12 +37,12 @@ func (r *TestRunner) theVersionStatusIs(versionID, expectedStatus string) error 
 	return nil
 }
 
-func (r *TestRunner) theAPIClientPublishTheVersionSendingComment(versionID, comment string) error {
-	return r.gqManager.VersionPublish(versionID, comment)
+func (r *TestRunner) theAPIClientPublishTheVersionSendingComment(versionName, comment string) error {
+	return r.gqManager.VersionPublish(versionName, comment)
 }
 
-func (r *TestRunner) theAPIClientUnpublishTheVersionSendingComment(versionID, comment string) error {
-	return r.gqManager.VersionUnpublish(versionID, comment)
+func (r *TestRunner) theAPIClientUnpublishTheVersionSendingComment(versionName, comment string) error {
+	return r.gqManager.VersionUnpublish(versionName, comment)
 }
 
 func (r *TestRunner) theAPIClientCallsToTheWorkflowTestAt(entrypointAddress string) error {


### PR DESCRIPTION
fix url composition on acceptance tests. This way avoids errors with double bar or no bar, and other common errors in url composition