### PR TITLE
fix: the url for the entrypoint shown in UI is not correct

### DIFF
--- a/engine/admin-api/adapter/gql/resolver.go
+++ b/engine/admin-api/adapter/gql/resolver.go
@@ -382,7 +382,7 @@ func (r *runtimeResolver) DatabaseURL(_ context.Context, obj *entity.Runtime) (s
 }
 
 func (r *runtimeResolver) EntrypointAddress(_ context.Context, obj *entity.Runtime) (string, error) {
-	return fmt.Sprintf("entrypoint.%s.%s", r.cfg.K8s.Namespace, r.cfg.BaseDomainName), nil
+	return fmt.Sprintf("entrypoint.%s", r.cfg.BaseDomainName), nil
 }
 
 func (r *subscriptionResolver) WatchVersion(ctx context.Context) (<-chan *entity.Version, error) {


### PR DESCRIPTION
- With the mono-namespace change the entrypoint URL becomes to "entrypoint.<base_domain_name>" instead of "entrypoint.<namespace>.<base_domain_name>"