### PR TITLE
fix sass calcs warnings

### DIFF
--- a/engine/admin-ui/src/Components/Tag/Tag.module.scss
+++ b/engine/admin-ui/src/Components/Tag/Tag.module.scss
@@ -8,7 +8,7 @@
   color: font-color(dark);
   background-color: palette(lowlight, 100);
   padding: 3px $grid-unit;
-  border-radius: $grid-unit / 2;
+  border-radius: calc($grid-unit / 2);
   margin-right: 1.5 * $grid-unit;
 
   &.WARNING {

--- a/engine/admin-ui/src/Pages/Version/components/VersionSideBar/RuntimeMenu/RuntimeMenu.module.scss
+++ b/engine/admin-ui/src/Pages/Version/components/VersionSideBar/RuntimeMenu/RuntimeMenu.module.scss
@@ -34,7 +34,7 @@
 
   .icon {
     line-height: 33px;
-    margin-right: $grid-unit / 2;
+    margin-right: calc($grid-unit / 2);
 
     svg {
       width: 10px;

--- a/engine/admin-ui/src/Pages/Version/pages/Status/components/Tooltip/Tooltip.module.scss
+++ b/engine/admin-ui/src/Pages/Version/pages/Status/components/Tooltip/Tooltip.module.scss
@@ -26,7 +26,7 @@ $color-bg: $bg-color-dark;
 .container {
   @include shadow(2);
 
-  border-radius: $grid-unit / 2;
+  border-radius: calc($grid-unit / 2);
   min-width: $grid-unit * 55;
   max-width: $grid-unit * 75;
   padding: 11px $padding-y;

--- a/engine/admin-ui/src/Styles/app.global.scss
+++ b/engine/admin-ui/src/Styles/app.global.scss
@@ -11,7 +11,7 @@
   opacity: 0;
   z-index: 2;
   background-color: palette(base, 800);
-  border-radius: $grid-unit / 2;
+  border-radius: calc($grid-unit / 2);
   width: fit-content;
   height: fit-content;
 


### PR DESCRIPTION
Avoid a SASS warning for making calculations outside the calc function. Although this was valid while using node-sass, updating the dependency deprecated it.