### PR TITLE
fix(api): Grant view logs permissions to VIEWER users.

### DIFF
--- a/engine/admin-api/adapter/auth/casbin_access_control.go
+++ b/engine/admin-api/adapter/auth/casbin_access_control.go
@@ -18,8 +18,8 @@ type CasbinAccessControl struct {
 	userRepo repository.UserRepo
 }
 
-func NewCasbinAccessControl(logger logging.Logger, userRepo repository.UserRepo) (*CasbinAccessControl, error) {
-	e, err := casbin.NewEnforcer("casbin_rbac_model.conf", "casbin_rbac_policy.csv")
+func NewCasbinAccessControl(logger logging.Logger, userRepo repository.UserRepo, modelPath, policyPath string) (*CasbinAccessControl, error) {
+	e, err := casbin.NewEnforcer(modelPath, policyPath)
 	if err != nil {
 		return nil, err
 	}

--- a/engine/admin-api/casbin_rbac_policy.csv
+++ b/engine/admin-api/casbin_rbac_policy.csv
@@ -2,9 +2,9 @@ p, VIEWER, metrics, view
 p, VIEWER, resource-metrics, view
 p, VIEWER, runtimes, view
 p, VIEWER, versions, view
+p, VIEWER, logs, view
 
 p, MANAGER, audits, view
-p, MANAGER, logs, view
 p, MANAGER, runtimes, edit
 p, MANAGER, versions, edit
 

--- a/engine/admin-api/main.go
+++ b/engine/admin-api/main.go
@@ -45,7 +45,7 @@ func main() {
 
 	loginLinkTransport := auth.NewSMTPLoginLinkTransport(cfg, logger)
 	verificationCodeGenerator := auth.NewUUIDVerificationCodeGenerator()
-	accessControl, err := auth.NewCasbinAccessControl(logger, userRepo)
+	accessControl, err := auth.NewCasbinAccessControl(logger, userRepo, "./casbin_rbac_model.conf", "./casbin_rbac_policy.csv")
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/engine/admin-ui/src/Mocks/GetVersionWorkflowsQuery.ts
+++ b/engine/admin-ui/src/Mocks/GetVersionWorkflowsQuery.ts
@@ -1,0 +1,3 @@
+import { workflowsMock } from './version';
+
+export default workflowsMock.result.data;

--- a/engine/admin-ui/src/Pages/Version/pages/Status/components/Workflow/WorkflowHeader.tsx
+++ b/engine/admin-ui/src/Pages/Version/pages/Status/components/Workflow/WorkflowHeader.tsx
@@ -21,6 +21,7 @@ function WorkflowHeader({ name = 'Workflow', onWorkflowClick }: Props) {
           className={styles.button}
           onClick={() => onWorkflowClick()}
           title="Open logs for this workflow"
+          data-testid="openWorkflowLogs"
         >
           <SvgIcon className="icon-small">
             <path d={TERMINAL} />

--- a/engine/admin-ui/src/Pages/Version/pages/Status/components/Workflow/__snapshots__/Workflow.spec.tsx.snap
+++ b/engine/admin-ui/src/Pages/Version/pages/Status/components/Workflow/__snapshots__/Workflow.spec.tsx.snap
@@ -1340,6 +1340,7 @@ exports[`Workflow matches snapshot 1`] = `
                   >
                     <div
                       className="button"
+                      data-testid="openWorkflowLogs"
                       onClick={[Function]}
                       title="Open logs for this workflow"
                     >

--- a/engine/admin-ui/src/Pages/Version/pages/Status/components/WorkflowsManager/__snapshots__/WorkflowsManager.spec.tsx.snap
+++ b/engine/admin-ui/src/Pages/Version/pages/Status/components/WorkflowsManager/__snapshots__/WorkflowsManager.spec.tsx.snap
@@ -1433,6 +1433,7 @@ exports[`WorkflowsManager matches snapshot 1`] = `
                       >
                         <div
                           className="button"
+                          data-testid="openWorkflowLogs"
                           onClick={[Function]}
                           title="Open logs for this workflow"
                         >

--- a/engine/admin-ui/src/rbac-rules.ts
+++ b/engine/admin-ui/src/rbac-rules.ts
@@ -1,8 +1,10 @@
 import { AccessLevel } from 'Graphql/types/globalTypes';
 
+const VIEWER_RULES = ['logs:view'];
+
 const MANAGER_RULES = [
+  ...VIEWER_RULES,
   'audit:view',
-  'logs:view',
   'runtime:edit',
   'version:edit'
 ];
@@ -16,7 +18,7 @@ const rules: {
   };
 } = {
   VIEWER: {
-    static: []
+    static: VIEWER_RULES
   },
   MANAGER: {
     static: MANAGER_RULES


### PR DESCRIPTION
Modify RBAC policy on API to grant view logs permissions to users with viewer role.
Fix the UI to allow viewer users to open the logs console. 