### PR TITLE
Add nodeSelector, taint and affinity options to influxdb and mongodb pods

### DIFF
--- a/helm/kre/templates/mongo/statefulset.yaml
+++ b/helm/kre/templates/mongo/statefulset.yaml
@@ -48,6 +48,18 @@ spec:
           configMap:
             name: kre-mongo-init-script
             defaultMode: 0777
+    {{- with .Values.mongodb.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.mongodb.affinity }}
+      affinity:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.prometheusOperator.tolerations }}
+      tolerations:
+{{ toYaml . | indent 8 }}
+    {{- end }}
   volumeClaimTemplates:
     - metadata:
         name: {{ .Release.Name }}-mongo-pvc

--- a/helm/kre/values.yaml
+++ b/helm/kre/values.yaml
@@ -31,6 +31,34 @@ mongodb:
     storageClass: standard
     size: 5Gi
 
+  ## Define which Nodes the Pods are scheduled on.
+  ## ref: https://kubernetes.io/docs/user-guide/node-selection/
+  ##
+  nodeSelector: {}
+
+  ## Assign custom affinity rules to the MongoDB pods
+  ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
+  ##
+  affinity: {}
+    # nodeAffinity:
+    #   requiredDuringSchedulingIgnoredDuringExecution:
+    #     nodeSelectorTerms:
+    #     - matchExpressions:
+    #       - key: kubernetes.io/e2e-az-name
+    #         operator: In
+    #         values:
+    #         - e2e-az1
+    #         - e2e-az2
+
+  ## Tolerations for use with node taints
+  ## ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+  ##
+  tolerations: []
+  # - key: "key"
+  #   operator: "Equal"
+  #   value: "value"
+  #   effect: "NoSchedule"
+
 # Config from kre/helm
 config:
   baseDomainName: "local"
@@ -157,6 +185,34 @@ influxdb:
     scripts:
       init.iql: |+
         CREATE DATABASE "kre"
+
+  ## Define which Nodes the Pods are scheduled on.
+  ## ref: https://kubernetes.io/docs/user-guide/node-selection/
+  ##
+  nodeSelector: {}
+
+  ## Assign custom affinity rules to the InfluxDB pods
+  ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
+  ##
+  affinity: {}
+    # nodeAffinity:
+    #   requiredDuringSchedulingIgnoredDuringExecution:
+    #     nodeSelectorTerms:
+    #     - matchExpressions:
+    #       - key: kubernetes.io/e2e-az-name
+    #         operator: In
+    #         values:
+    #         - e2e-az1
+    #         - e2e-az2
+
+  ## Tolerations for use with node taints
+  ## ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+  ##
+  tolerations: []
+  # - key: "key"
+  #   operator: "Equal"
+  #   value: "value"
+  #   effect: "NoSchedule"
 
 ## Using default values from https://github.com/influxdata/helm-charts/blob/master/charts/kapacitor/values.yaml
 ##


### PR DESCRIPTION
* Add _nodeSelector_, _taint_ and _affinity options_ to **mongodb** pods
* Add default values for _nodeSelector_, _taint_ and _affinity_ options in `values.yaml` for **InfluxDb** bsubchart