### PR TITLE
fix(ui): navigation to status page after navigating to another page

### DIFF
--- a/engine/admin-ui/src/Pages/Version/pages/Status/Status.tsx
+++ b/engine/admin-ui/src/Pages/Version/pages/Status/Status.tsx
@@ -68,6 +68,8 @@ function Status({ version, runtime }: Props) {
   useEffect(
     () => {
       if(!loading && !error) {
+        // the useEffect return line executes when on component unmount, so we can't avoid using an additional
+        // variable for the unsubscribe functionality
         const unsubscribe = subscribe(); // NOSONAR
         return unsubscribe;
       }

--- a/engine/admin-ui/src/Pages/Version/pages/Status/Status.tsx
+++ b/engine/admin-ui/src/Pages/Version/pages/Status/Status.tsx
@@ -68,7 +68,7 @@ function Status({ version, runtime }: Props) {
   useEffect(
     () => {
       if(!loading && !error) {
-        const unsubscribe = subscribe();
+        const unsubscribe = subscribe(); // NOSONAR
         return unsubscribe;
       }
     },

--- a/engine/admin-ui/src/Pages/Version/pages/Status/Status.tsx
+++ b/engine/admin-ui/src/Pages/Version/pages/Status/Status.tsx
@@ -13,7 +13,7 @@ import {
 } from 'Graphql/subscriptions/types/WatchVersionNodeStatus';
 
 import { NodeStatus } from 'Graphql/types/globalTypes';
-import React from 'react';
+import React, { useEffect } from 'react';
 import { VersionRouteParams } from 'Constants/routes';
 import WorkflowsManager from './components/WorkflowsManager/WorkflowsManager';
 import styles from './Status.module.scss';
@@ -45,7 +45,6 @@ function Status({ version, runtime }: Props) {
     GetVersionWorkflowsVariables
   >(GetVersionWorkflowsQuery, {
     variables: { versionName },
-    onCompleted: () => subscribe()
   });
 
   const dataOpenedVersion = useReactiveVar(openedVersion);
@@ -65,6 +64,16 @@ function Status({ version, runtime }: Props) {
         return prev;
       }
     });
+
+  useEffect(
+    () => {
+      if(!loading && !error) {
+        const unsubscribe = subscribe();
+        return unsubscribe;
+      }
+    },
+    [loading, error, subscribe],
+  );
 
   if (error) return <ErrorMessage />;
   if (loading) return <SpinnerCircular />;


### PR DESCRIPTION
When navigating to the status page of a project after navigating to predictions o configuration, the component render fails because the management of a GraphQL subscriptions has a circular dependency. In the first load of status it works because the subscribe function its declared properly, but if its reloaded, this functions isnt declared when the onComplete of the GraphQL useQuery is executed.
To avoid this behavior, the management of the subscription has been move to a useEffect hook, that also manage the unsubscribe, preventing errors related to a high number of subscriptions.