### PR TITLE
fix(readme): typo in helm command

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,9 +21,9 @@
 # KRE (Konstellation Runtime Engine)
 
 Konstellation Runtime Engine is an application that allow to run AI/ML models for inference based on the content of a
- `.krt` file. 
+`.krt` file.
 
- ## Engine
+## Engine
 
 |  Component  | Coverage  |  Bugs  |  Maintainability Rating  |
 | :---------: | :-----:   |  :---: |  :--------------------:  |
@@ -55,8 +55,9 @@ Below are described the main concepts of KRE.
 
 ## Engine
 
-Before installing KRE an already existing Kubernetes namespace is required as a general rule the name used to be `KRE` but can be any value. The installation process will deploy some
-components that are responsible to manage the full life cycle of AI solution.
+Before installing KRE an already existing Kubernetes namespace is required as a general rule the name used to be `KRE`
+but can be any value. The installation process will deploy some components that are responsible to manage the full life
+cycle of AI solution.
 
 The Engine is composed by the following components:
 
@@ -77,7 +78,7 @@ The base structure of a `kre.yaml` is as follows:
 ```yaml
 version: my-project-v1
 description: This is the new version that solves some problems.
-entrypoint: 
+entrypoint:
   proto: public_input.proto
   image: konstellation/kre-runtime-entrypoint:latest
 
@@ -89,21 +90,21 @@ config:
     - HTTPS_CERT
 
 nodes:
- - name: ETL
-   image: konstellation/kre-py:latest
-   src: src/etl/execute_etl.py
- 
- - name: Execute DL Model
-   image: konstellation/kre-py:latest
-   src: src/execute_model/execute_model.py
+  - name: ETL
+    image: konstellation/kre-py:latest
+    src: src/etl/execute_etl.py
 
- - name: Create Output
-   image: konstellation/kre-py:latest
-   src: src/output/output.py
+  - name: Execute DL Model
+    image: konstellation/kre-py:latest
+    src: src/execute_model/execute_model.py
 
- - name: Client Metrics
-   image: konstellation/kre-py:latest
-   src: src/client_metrics/client_metrics.py
+  - name: Create Output
+    image: konstellation/kre-py:latest
+    src: src/output/output.py
+
+  - name: Client Metrics
+    image: konstellation/kre-py:latest
+    src: src/client_metrics/client_metrics.py
 
 workflows:
   - name: New prediction
@@ -121,8 +122,8 @@ workflows:
 
 # Install
 
-KRE can be installed only on top of a Kubernetes cluster, and is packetized as a Helm Chart. In order to install it 
-just need to add the chart repository, define your custom `values.yaml` and run one command.
+KRE can be installed only on top of a Kubernetes cluster, and is packetized as a Helm Chart. In order to install it just
+need to add the chart repository, define your custom `values.yaml` and run one command.
 
 Let's start adding the repository to helm:
 
@@ -131,13 +132,14 @@ helm repo add konstellation-io https://charts.konstellation.io
 helm repo update
 ```
 
-Now define your custom `values.yaml`, you can get the default values using this command (this can be used as a template to customize yours later):
+Now define your custom `values.yaml`, you can get the default values using this command (this can be used as a template
+to customize yours later):
 
 ```bash
-helm show values konstellation.io/kre
+helm show values konstellation-io/kre
 ```
 
-Once you have the appropriate values, you can start the installation with the following command: 
+Once you have the appropriate values, you can start the installation with the following command:
 
 ```bash
 helm upgrade --install kre --namespace kre \
@@ -159,21 +161,18 @@ KRE allows a custom configuration to use parts that already exist in your infras
 | -------------------------- | ----- |
 | prometheusOperator.enabled | false |
 
-
-# Development 
-
+# Development
 
 ## Requirements
 
-In order to start development on this project you will need these tools: 
+In order to start development on this project you will need these tools:
 
 - **gettext**: OS package to fill templates during deployment
 - **minikube**: the local version of Kubernetes to deploy KRE
 - **helm**: K8s package manager. Make sure you have v3+
 - **yq**: YAML processor. Make sure you have v4+
 
-*NOTE*: If you still have Helm v2 update variable `$HELM_VERSION` in file `.krectl.conf`. 
-
+*NOTE*: If you still have Helm v2 update variable `$HELM_VERSION` in file `.krectl.conf`.
 
 ## Local Environment
 
@@ -244,19 +243,27 @@ You will see an output like this:
 
 # Versioning lifecycle
 
-In the development lifecycle of KLI there are three main stages depend if we are going to add a new feature, release a new version with some features or apply a fix to a current release.
+In the development lifecycle of KLI there are three main stages depend if we are going to add a new feature, release a
+new version with some features or apply a fix to a current release.
 
 ### Alphas
 
-In order to add new features just create a feature branch from main, and after the merger the Pull Request a workflow will run the tests and if everything passes a new alpha tag will be created (like *v0.0-alpha.0*), and a new release will be generated with this tag.
+In order to add new features just create a feature branch from main, and after the merger the Pull Request a workflow
+will run the tests and if everything passes a new alpha tag will be created (like *v0.0-alpha.0*), and a new release
+will be generated with this tag.
 
 ### Releases
 
-After some alpha versions we can create what we call a release, and to do that we have to run manual the Release Action. This workflow will create a new release branch and a new tag like *v0.0.0*. With this tag, a new release will be generated.
+After some alpha versions we can create what we call a release, and to do that we have to run manual the Release Action.
+This workflow will create a new release branch and a new tag like *v0.0.0*. With this tag, a new release will be
+generated.
 
 ### Fixes
 
-If we find out a bug in a release, we can apply a bugfix just by creating a fixed branch from the specific release branch, and creating a Pull Request to the same release branch. When the Pull Request is merged, after passing the tests, a new fix tag will be created just by increasing the patch number of the version, and a new release will be build and released.
+If we find out a bug in a release, we can apply a bugfix just by creating a fixed branch from the specific release
+branch, and creating a Pull Request to the same release branch. When the Pull Request is merged, after passing the
+tests, a new fix tag will be created just by increasing the patch number of the version, and a new release will be build
+and released.
 
 
 [admin-ui-coverage]: https://sonarcloud.io/api/project_badges/measure?project=konstellation-io_kre_admin_ui&metric=coverage

--- a/README.md
+++ b/README.md
@@ -39,15 +39,13 @@ Konstellation Runtime Engine is an application that allow to run AI/ML models fo
 
 ## Runners
 
-All runners for different languages are located on [kre-runners repo](https://github.com/konstellation-io/kre-runners).
-
-Clone the `kre-runners` repository in a `runners` folder inside this repository, located at the root level.
+Each language has a specialized runner associated with it. They are located at the [kre-runners repo](https://github.com/konstellation-io/kre-runners). You must clone that repository in a folder named `runners` at the root level inside this repository.
 
 # Architecture
 
-KRE is designed based on a microservice pattern to be run on top of a Kubernetes cluster.
+KRE design is based on a microservice pattern to be run on top of a Kubernetes cluster.
 
-In the following diagram is described the main components and the relationship each other.
+The following diagram shows the main components and how they relate with each other.
 
 ![Architecture](.github/images/kre-architecture.jpg)
 
@@ -55,11 +53,9 @@ Below are described the main concepts of KRE.
 
 ## Engine
 
-Before installing KRE an already existing Kubernetes namespace is required as a general rule the name used to be `KRE`
-but can be any value. The installation process will deploy some components that are responsible to manage the full life
-cycle of AI solution.
+Before installing KRE an already existing Kubernetes namespace is required. It will be named `kre` by convention, but feel free to use whatever you like. The installation process will deploy some components that are responsible of managing the full lifecycle of this AI solution.
 
-The Engine is composed by the following components:
+The Engine is composed of the following components:
 
 * [Admin UI](engine/admin-ui/README.md)
 * [Admin API](engine/admin-api/README.md)
@@ -70,10 +66,9 @@ The Engine is composed by the following components:
 
 ### KRT
 
-Konstellation Runtime Transport is a compressed file with the definition of a runtime version, included the code to run,
-and a YAML file called `kre.yaml` with the desired workflows definitions.
+_Konstellation Runtime Transport_ is a compressed file containing the definition of a runtime version, including the code that must be executed, and a YAML file called `kre.yaml` describing the desired workflows definitions.
 
-The base structure of a `kre.yaml` is as follows:
+The generic structure of a `kre.yaml` is as follows:
 
 ```yaml
 version: my-project-v1
@@ -122,8 +117,7 @@ workflows:
 
 # Install
 
-KRE can be installed only on top of a Kubernetes cluster, and is packetized as a Helm Chart. In order to install it just
-need to add the chart repository, define your custom `values.yaml` and run one command.
+KRE can be installed only on top of a Kubernetes cluster, and is packetized as a Helm Chart. In order to install it you just need to add the chart repository, define your custom `values.yaml` file and run one command.
 
 Let's start adding the repository to helm:
 
@@ -132,14 +126,13 @@ helm repo add konstellation-io https://charts.konstellation.io
 helm repo update
 ```
 
-Now define your custom `values.yaml`, you can get the default values using this command (this can be used as a template
-to customize yours later):
+Now define your custom `values.yaml` file, you can get the default values using this command (this can be used as a template to customize yours later):
 
 ```bash
 helm show values konstellation-io/kre
 ```
 
-Once you have the appropriate values, you can start the installation with the following command:
+Once you have customized the values according to your needs, you can start the installation by executing the following command:
 
 ```bash
 helm upgrade --install kre --namespace kre \
@@ -147,15 +140,15 @@ helm upgrade --install kre --namespace kre \
  konstellation-io/kre
 ```
 
-***NOTE***: You can also check default values for the installation in this repository [file](./helm/kre/values.yaml).
+***NOTE***: The chart default values are also available in this [repository](./helm/kre/values.yaml).
 
 ## Custom Installation
 
-KRE allows a custom configuration to use parts that already exist in your infrastructure.
+KRE allows custom configurations to use existing parts already present in your infrastructure.
 
 ### Prometheus
 
-- Prometheus will be installed by default if you prefer use your own prometheus, use this helm parameter:
+- Prometheus will be installed by default. If you prefer using your own Prometheus installation, modify this helm parameter:
 
 |       Param                | Value |
 | -------------------------- | ----- |
@@ -176,10 +169,9 @@ In order to start development on this project you will need these tools:
 
 ## Local Environment
 
-This repo contains a tool called `./krectl.sh` to handle common actions you need during development.
+This repo contains a tool called `./krectl.sh` to handle common actions you will need during development.
 
-All the configuration needed to run KRE locally can be found in `.krectl.conf` file. Usually you'd be ok with the
-default values. Check Minikube parameters if you need to tweak the resources assigned to it.
+All the configuration needed to run KRE locally can be found in `.krectl.conf` file. Usually you'd be ok with the default values. Check Minikube's parameters if you need to tweak the resources assigned to it.
 
 Run help to get info for each command:
 
@@ -214,24 +206,23 @@ To install KRE in your local environment:
 $ ./krectl.sh dev
 ```
 
-It will install everything in the namespace specified in your development `.kreconf` file.
+It will install everything in the namespace specified in your development `.krectl.conf` file.
 
 ### Login to local environment
 
 First, remember to edit your `/etc/hosts`, see `./krectl.sh dev` output for more details.
 
-NOTE: If you have [hostctl](https://github.com/guumaster/hostctl) installed, updating `/etc/hosts` will be done
-automatically too.
+**NOTE**: If you have the [hostctl](https://github.com/guumaster/hostctl) tool installed, updating `/etc/hosts` will be done automatically too.
 
-In order to access the admin app, the login process can be done automatically using this script:
+Now you can access the admin UI visiting the login URL that will be opened automatically by executing the following script:
 
-```
+```bash
 $ ./krectl.sh login [--new]
 ```
 
 You will see an output like this:
 
-```
+```bash
 ⏳ Calling Admin API...
 
  Login done. Open your browser at:
@@ -243,27 +234,20 @@ You will see an output like this:
 
 # Versioning lifecycle
 
-In the development lifecycle of KLI there are three main stages depend if we are going to add a new feature, release a
-new version with some features or apply a fix to a current release.
+There are three stages in the development lifecycle of KRE there are three main stages depending on if we are going to add a new feature, release a new version with some features or apply a fix to a current release.
 
 ### Alphas
 
-In order to add new features just create a feature branch from main, and after the merger the Pull Request a workflow
-will run the tests and if everything passes a new alpha tag will be created (like *v0.0-alpha.0*), and a new release
-will be generated with this tag.
+To add new features just create a feature branch from main, and after merging the Pull Request a workflow will run the tests. If all tests pass, a new `alpha` tag will be created (e.g *v0.0-alpha.0*), and a new release will be generated from this tag.
 
 ### Releases
 
-After some alpha versions we can create what we call a release, and to do that we have to run manual the Release Action.
-This workflow will create a new release branch and a new tag like *v0.0.0*. With this tag, a new release will be
-generated.
+After releasing a number of alpha versions, you would want to create a release version. This process must be triggered with the Release workflow, that is a manual process.
+This workflow will create a new release branch and a new tag following the pattern *v0.0.0*. Along this tag, a new release will be created.
 
 ### Fixes
 
-If we find out a bug in a release, we can apply a bugfix just by creating a fixed branch from the specific release
-branch, and creating a Pull Request to the same release branch. When the Pull Request is merged, after passing the
-tests, a new fix tag will be created just by increasing the patch number of the version, and a new release will be build
-and released.
+If you find out a bug in a release, you can apply a bugfix just by creating a `fix` branch from the specific release branch, and create a Pull Request towards the same release branch. When merged, the tests will be run against it, and after passing all the tests, a new `fix tag` will be created increasing the patch portion of the version, and a new release will be build and released.
 
 
 [admin-ui-coverage]: https://sonarcloud.io/api/project_badges/measure?project=konstellation-io_kre_admin_ui&metric=coverage


### PR DESCRIPTION
Fix a typo in the README in a helm command (line 139).

The rest of the changes in the commit are re-formatting the README to adhere to standards.