### PR TITLE
fix(helm): Ingresses tls default annotations generation

### DIFF
--- a/helm/kre/templates/engine/admin-api/ingress.yaml
+++ b/helm/kre/templates/engine/admin-api/ingress.yaml
@@ -4,6 +4,7 @@ kind: Route
 metadata:
   name: {{ .Release.Name }}-admin-api-route
   annotations:
+    {{- if and .Values.certManager.enabled .Values.adminApi.tls.enabled }}
     kubernetes.io/tls-acme: "true"
     cert-manager.io/issuer: {{ .Release.Name }}-admin-api
     {{ if hasKey .Values.certManager "dns01" -}}
@@ -11,6 +12,7 @@ metadata:
     {{ else -}}
     cert-manager.io/acme-challenge-type: "http01"
     {{ end }}
+    {{- end }}
 {{- if .Values.adminApi.ingress.annotations }}
 {{ toYaml .Values.adminApi.ingress.annotations | indent 4 }}
 {{- end }}
@@ -38,14 +40,16 @@ kind: Ingress
 metadata:
   name: {{ .Release.Name }}-admin-api-ingress
   annotations:
+    {{- if and .Values.certManager.enabled .Values.adminApi.tls.enabled }}
     kubernetes.io/tls-acme: "true"
-    kubernetes.io/ingress.class: nginx
     cert-manager.io/issuer: {{ .Release.Name }}-admin-api
     {{ if hasKey .Values.certManager "dns01" -}}
     cert-manager.io/acme-challenge-type: "dns01"
     {{ else -}}
     cert-manager.io/acme-challenge-type: "http01"
     {{ end }}
+    {{- end }}
+    kubernetes.io/ingress.class: nginx
     nginx.ingress.kubernetes.io/proxy-body-size: 100000m
     nginx.org/client-max-body-size: 100000m
     nginx.org/websocket-services: admin-api

--- a/helm/kre/templates/engine/admin-api/issuer.yaml
+++ b/helm/kre/templates/engine/admin-api/issuer.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.certManager.enabled }}
+{{- if and .Values.certManager.enabled .Values.adminApi.tls.enabled }}
 {{ if .Capabilities.APIVersions.Has "cert-manager.io/v1alpha3" }}
 apiVersion: cert-manager.io/v1alpha3
 {{ else }}
@@ -22,4 +22,4 @@ spec:
       - http01:
         {{- toYaml . | nindent 10 }}
       {{- end }}
-  {{- end }}
+{{- end }}

--- a/helm/kre/templates/engine/admin-ui/ingress.yaml
+++ b/helm/kre/templates/engine/admin-ui/ingress.yaml
@@ -4,6 +4,7 @@ kind: Route
 metadata:
   name: {{ .Release.Name }}-admin-ui-route
   annotations:
+    {{- if and .Values.certManager.enabled .Values.adminUI.tls.enabled }}
     kubernetes.io/tls-acme: "true"
     cert-manager.io/issuer: {{ .Release.Name }}-admin-ui
     {{ if hasKey .Values.certManager "dns01" -}}
@@ -11,6 +12,7 @@ metadata:
     {{ else -}}
     cert-manager.io/acme-challenge-type: "http01"
     {{ end }}
+    {{- end }}
 {{- if .Values.adminUI.ingress.annotations }}
 {{ toYaml .Values.adminUI.ingress.annotations | indent 4 }}
 {{- end }}
@@ -38,14 +40,16 @@ kind: Ingress
 metadata:
   name: {{ .Release.Name }}-admin-ui-ingress
   annotations:
+    {{- if and .Values.certManager.enabled .Values.adminUI.tls.enabled }}
     kubernetes.io/tls-acme: "true"
-    kubernetes.io/ingress.class: nginx
     cert-manager.io/issuer: {{ .Release.Name }}-admin-ui
     {{ if hasKey .Values.certManager "dns01" -}}
     cert-manager.io/acme-challenge-type: "dns01"
     {{ else -}}
     cert-manager.io/acme-challenge-type: "http01"
     {{ end }}
+    {{- end }}
+    kubernetes.io/ingress.class: nginx
 {{- if .Values.adminUI.ingress.annotations }}
 {{ toYaml .Values.adminUI.ingress.annotations | indent 4 }}
 {{- end }}

--- a/helm/kre/templates/engine/admin-ui/issuer.yaml
+++ b/helm/kre/templates/engine/admin-ui/issuer.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.certManager.enabled }}
+{{- if and .Values.certManager.enabled .Values.adminUI.tls.enabled }}
 {{ if .Capabilities.APIVersions.Has "cert-manager.io/v1alpha3" }}
 apiVersion: cert-manager.io/v1alpha3
 {{ else }}
@@ -22,4 +22,4 @@ spec:
       - http01:
         {{- toYaml . | nindent 10 }}
       {{- end }}
-  {{- end }}
+{{- end }}

--- a/helm/kre/templates/engine/entrypoint/grpc-ingress.yaml
+++ b/helm/kre/templates/engine/entrypoint/grpc-ingress.yaml
@@ -4,7 +4,7 @@ kind: Route
 metadata:
   name: {{ template "runtime.fullname" . }}-entrypoint
   annotations:
-    {{ if .Values.entrypoint.tls }}
+    {{ if and .Values.certManager.enabled .Values.entrypoint.tls }}
     kubernetes.io/tls-acme: "true"
     cert-manager.io/cluster-issuer: {{ include "runtime.name" . }}-clusterissuer-runtimes-entrypoints
     {{ end }}
@@ -36,10 +36,10 @@ metadata:
   name: {{ template "runtime.fullname" . }}-entrypoint
   annotations:
     kubernetes.io/ingress.class: "nginx"
-    {{ if .Values.entrypoint.tls }}
+    {{- if and .Values.certManager.enabled .Values.entrypoint.tls }}
     kubernetes.io/tls-acme: "true"
     cert-manager.io/cluster-issuer: {{ include "runtime.name" . }}-clusterissuer-runtimes-entrypoints
-    {{ end }}
+    {{- end }}
     nginx.ingress.kubernetes.io/proxy-body-size: 16m
     nginx.ingress.kubernetes.io/backend-protocol: "GRPC"
     # Based on this snippet:

--- a/helm/kre/templates/engine/entrypoint/nginx-ingress.yaml
+++ b/helm/kre/templates/engine/entrypoint/nginx-ingress.yaml
@@ -4,10 +4,10 @@ kind: Route
 metadata:
   name: {{ template "runtime.fullname" . }}-entrypoint-web
   annotations:
-    {{ if .Values.entrypoint.tls }}
+    {{- if and .Values.certManager.enabled .Values.entrypoint.tls }}
     kubernetes.io/tls-acme: "true"
     cert-manager.io/cluster-issuer: {{ include "runtime.name" . }}-clusterissuer-runtimes-entrypoints
-    {{ end }}
+    {{- end }}
 {{- if .Values.entrypoint.ingress.annotations }}
 {{ toYaml .Values.entrypoint.ingress.annotations | indent 4 }}
 {{- end }}
@@ -36,10 +36,10 @@ metadata:
   name: {{ template "runtime.fullname" . }}-entrypoint-web
   annotations:
     kubernetes.io/ingress.class: "nginx"
-    {{ if .Values.entrypoint.tls }}
+    {{- if and .Values.entrypoint.tls .Values.certManager.enabled }}
     kubernetes.io/tls-acme: "true"
     cert-manager.io/cluster-issuer: {{ include "runtime.name" . }}-clusterissuer-runtimes-entrypoints
-    {{ end }}
+    {{- end }}
     nginx.ingress.kubernetes.io/default-backend: runtime-default-backend
     nginx.ingress.kubernetes.io/custom-http-errors: "404,503,502"
 {{- if .Values.entrypoint.ingress.annotations }}


### PR DESCRIPTION
Now default ingress anotations depend on `.Values.<component>.tls.enabled` and `.Values.certManager.enabled`

Closes #557