### PR TITLE
fix(helm): admin-api and admin-ui deployment and service selector labels

### DIFF
--- a/helm/kre/templates/_helpers.tpl
+++ b/helm/kre/templates/_helpers.tpl
@@ -44,10 +44,6 @@ app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end -}}
 
-
-
-
-
 {{/* vim: set filetype=mustache: */}}
 {{/*
 Expand the name of the chart.

--- a/helm/kre/templates/engine/admin-api/deployment.yaml
+++ b/helm/kre/templates/engine/admin-api/deployment.yaml
@@ -10,13 +10,14 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      {{- include "kre.labels" . | nindent 6 }}
       app: {{ .Release.Name }}-admin-api
+      release: {{ $.Release.Name | quote }}
   template:
     metadata:
       labels:
         {{- include "kre.labels" . | nindent 8 }}
         app: {{ .Release.Name }}-admin-api
+        release: {{ $.Release.Name | quote }}
         type: admin
       annotations:
         helm.sh/restart-deployment: {{ randAlphaNum 5 | quote }}

--- a/helm/kre/templates/engine/admin-api/service.yaml
+++ b/helm/kre/templates/engine/admin-api/service.yaml
@@ -15,3 +15,4 @@ spec:
   selector:
     {{- include "kre.labels" . | nindent 4 }}
     app: {{ .Release.Name }}-admin-api
+    release: {{ $.Release.Name | quote }}

--- a/helm/kre/templates/engine/admin-ui/deployment.yaml
+++ b/helm/kre/templates/engine/admin-ui/deployment.yaml
@@ -10,13 +10,14 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      {{- include "kre.labels" . | nindent 6 }}
       app: {{ .Release.Name }}-admin-ui
+      release: {{ $.Release.Name | quote }}
   template:
     metadata:
       labels:
         {{- include "kre.labels" . | nindent 8 }}
         app: {{ .Release.Name }}-admin-ui
+        release: {{ $.Release.Name | quote }}
         type: admin
       annotations:
         helm.sh/restart-deployment: {{ randAlphaNum 5 | quote }}

--- a/helm/kre/templates/engine/admin-ui/service.yaml
+++ b/helm/kre/templates/engine/admin-ui/service.yaml
@@ -15,3 +15,4 @@ spec:
   selector:
     {{- include "kre.labels" . | nindent 4 }}
     app: {{ .Release.Name }}-admin-ui
+    release: {{ $.Release.Name | quote }}

--- a/helm/kre/templates/engine/k8s-manager/deployment.yaml
+++ b/helm/kre/templates/engine/k8s-manager/deployment.yaml
@@ -10,13 +10,14 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      {{- include "kre.labels" . | nindent 6 }}
       app: {{ .Release.Name }}-k8s-manager
+      release: {{ $.Release.Name | quote }}
   template:
     metadata:
       labels:
         {{- include "kre.labels" . | nindent 8 }}
         app: {{ .Release.Name }}-k8s-manager
+        release: {{ $.Release.Name | quote }}
         type: admin
       annotations:
         helm.sh/restart-deployment: {{ randAlphaNum 5 | quote }}

--- a/helm/kre/templates/engine/k8s-manager/service.yaml
+++ b/helm/kre/templates/engine/k8s-manager/service.yaml
@@ -13,5 +13,5 @@ spec:
       protocol: TCP
       targetPort: grpc
   selector:
-    {{- include "kre.labels" . | nindent 4 }}
     app: {{ .Release.Name }}-k8s-manager
+    release: {{ $.Release.Name | quote }}


### PR DESCRIPTION
Fixes the following error when upgrading from previous releases:

```
Error: UPGRADE FAILED: cannot patch "kre-admin-api" with kind Deployment: Deployment.apps "kre-admin-api" is invalid: spec.selector: Invalid value: v1.LabelSelector{MatchLabels:map[string]string{"app":"kre-admin-api", "app.kubernetes.io/instance":"kre", "app.kubernetes.io/managed-by":"Helm", "app.kubernetes.io/name":"kre", "app.kubernetes.io/version":"v1.7.0", "helm.sh/chart":"kre"}, MatchExpressions:[]v1.LabelSelectorRequirement(nil)}: field is immutable && cannot patch "kre-admin-ui" with kind Deployment: Deployment.apps "kre-admin-ui" is invalid: spec.selector: Invalid value: v1.LabelSelector{MatchLabels:map[string]string{"app":"kre-admin-ui", "app.kubernetes.io/instance":"kre", "app.kubernetes.io/managed-by":"Helm", "app.kubernetes.io/name":"kre", "app.kubernetes.io/version":"v1.7.0", "helm.sh/chart":"kre"}, MatchExpressions:[]v1.LabelSelectorRequirement(nil)}: field is immutable && cannot patch "kre-k8s-manager" with kind Deployment: Deployment.apps "kre-k8s-manager" is invalid: spec.selector: Invalid value: v1.LabelSelector{MatchLabels:map[string]string{"app":"kre-k8s-manager", "app.kubernetes.io/instance":"kre", "app.kubernetes.io/managed-by":"Helm", "app.kubernetes.io/name":"kre", "app.kubernetes.io/version":"v1.7.0", "helm.sh/chart":"kre"}, MatchExpressions:[]v1.LabelSelectorRequirement(nil)}: field is immutable
```