### PR TITLE
refactor: Remove all Openshift routes from ingress templates

### DIFF
--- a/helm/kre/templates/engine/admin-api/ingress.yaml
+++ b/helm/kre/templates/engine/admin-api/ingress.yaml
@@ -1,34 +1,3 @@
-{{ if .Capabilities.APIVersions.Has "route.openshift.io/v1/Route" }}
-apiVersion: route.openshift.io/v1
-kind: Route
-metadata:
-  name: {{ .Release.Name }}-admin-api-route
-  annotations:
-    {{- if and .Values.certManager.enabled .Values.adminApi.tls.enabled }}
-    kubernetes.io/tls-acme: "true"
-    cert-manager.io/issuer: {{ .Release.Name }}-admin-api
-    {{ if hasKey .Values.certManager "dns01" -}}
-    cert-manager.io/acme-challenge-type: "dns01"
-    {{ else -}}
-    cert-manager.io/acme-challenge-type: "http01"
-    {{ end }}
-    {{- end }}
-{{- if .Values.adminApi.ingress.annotations }}
-{{ toYaml .Values.adminApi.ingress.annotations | indent 4 }}
-{{- end }}
-  labels:
-    {{- include "kre.labels" . | nindent 4 }}
-    app: {{ .Release.Name }}-admin-api-route
-spec:
-  host: {{ .Values.adminApi.host }}
-  path: /  
-  port:
-    targetPort: grpc
-  to:
-    kind: Service
-    name: admin-api
-    weight: 100
-{{ else }}
 {{ if .Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" }}
 apiVersion: networking.k8s.io/v1
 {{ else if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1/Ingress" }}
@@ -84,4 +53,3 @@ spec:
               serviceName: admin-api
               servicePort: grpc
           {{ end }} 
-{{ end }}

--- a/helm/kre/templates/engine/admin-ui/ingress.yaml
+++ b/helm/kre/templates/engine/admin-ui/ingress.yaml
@@ -1,34 +1,3 @@
-{{ if .Capabilities.APIVersions.Has "route.openshift.io/v1/Route" }}
-apiVersion: route.openshift.io/v1
-kind: Route
-metadata:
-  name: {{ .Release.Name }}-admin-ui-route
-  annotations:
-    {{- if and .Values.certManager.enabled .Values.adminUI.tls.enabled }}
-    kubernetes.io/tls-acme: "true"
-    cert-manager.io/issuer: {{ .Release.Name }}-admin-ui
-    {{ if hasKey .Values.certManager "dns01" -}}
-    cert-manager.io/acme-challenge-type: "dns01"
-    {{ else -}}
-    cert-manager.io/acme-challenge-type: "http01"
-    {{ end }}
-    {{- end }}
-{{- if .Values.adminUI.ingress.annotations }}
-{{ toYaml .Values.adminUI.ingress.annotations | indent 4 }}
-{{- end }}
-  labels:
-    {{- include "kre.labels" . | nindent 4 }}
-    app: {{ .Release.Name }}-admin-ui-route
-spec:
-  host: {{ .Values.adminUI.host }}
-  path: /  
-  port:
-    targetPort: web
-  to:
-    kind: Service
-    name: admin-ui
-    weight: 100
-{{ else }}
 {{ if .Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" }}
 apiVersion: networking.k8s.io/v1
 {{ else if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1/Ingress" }}
@@ -81,4 +50,3 @@ spec:
               serviceName: admin-ui
               servicePort: web
           {{ end }} 
-{{ end }}

--- a/helm/kre/templates/engine/entrypoint/grpc-ingress.yaml
+++ b/helm/kre/templates/engine/entrypoint/grpc-ingress.yaml
@@ -1,29 +1,3 @@
-{{ if .Capabilities.APIVersions.Has "route.openshift.io/v1/Route" }}
-apiVersion: route.openshift.io/v1
-kind: Route
-metadata:
-  name: {{ template "runtime.fullname" . }}-entrypoint
-  annotations:
-    {{ if and .Values.certManager.enabled .Values.entrypoint.tls }}
-    kubernetes.io/tls-acme: "true"
-    cert-manager.io/cluster-issuer: {{ include "runtime.name" . }}-clusterissuer-runtimes-entrypoints
-    {{ end }}
-{{- if .Values.entrypoint.grpc.ingress.annotations }}
-{{ toYaml .Values.entrypoint.grpc.ingress.annotations | indent 4 }}
-{{- end }}
-  labels:
-    {{- include "kre.labels" . | nindent 4 }}
-    app: {{ template "runtime.fullname" . }}-entrypoint
-spec:
-  host: entrypoint.{{ .Values.entrypoint.host }}
-  path: /  
-  port:
-    targetPort: grpc
-  to:
-    kind: Service
-    name: active-entrypoint
-    weight: 100
-{{ else }}
 {{ if .Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" }}
 apiVersion: networking.k8s.io/v1
 {{ else if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1/Ingress" }}
@@ -87,4 +61,3 @@ spec:
               serviceName: active-entrypoint
               servicePort: grpc
         {{ end }}
-{{ end }}

--- a/helm/kre/templates/engine/entrypoint/nginx-ingress.yaml
+++ b/helm/kre/templates/engine/entrypoint/nginx-ingress.yaml
@@ -1,29 +1,3 @@
-{{ if .Capabilities.APIVersions.Has "route.openshift.io/v1/Route" }}
-apiVersion: route.openshift.io/v1
-kind: Route
-metadata:
-  name: {{ template "runtime.fullname" . }}-entrypoint-web
-  annotations:
-    {{- if and .Values.certManager.enabled .Values.entrypoint.tls }}
-    kubernetes.io/tls-acme: "true"
-    cert-manager.io/cluster-issuer: {{ include "runtime.name" . }}-clusterissuer-runtimes-entrypoints
-    {{- end }}
-{{- if .Values.entrypoint.ingress.annotations }}
-{{ toYaml .Values.entrypoint.ingress.annotations | indent 4 }}
-{{- end }}
-  labels:
-    {{- include "kre.labels" . | nindent 4 }}
-    app: {{ template "runtime.fullname" . }}-entrypoint-web
-spec:
-  host: proto.{{ .Values.entrypoint.host }}
-  path: /  
-  port:
-    targetPort: web
-  to:
-    kind: Service
-    name: active-entrypoint
-    weight: 100
-{{ else }}
 {{ if .Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" }}
 apiVersion: networking.k8s.io/v1
 {{ else if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1/Ingress" }}
@@ -70,4 +44,3 @@ spec:
               serviceName: active-entrypoint
               servicePort: web
         {{ end }}
-{{ end }}


### PR DESCRIPTION
Removed Openshift routes as they are being unmantained.

**IMPORTANT**: This PR introduces a breaking change as Openshift routes are no longer part of the Helm chart.

Closes #570