### PR TITLE
Fix: Template chomps

### DIFF
--- a/helm/kre/templates/engine/entrypoint/nginx-ingress.yaml
+++ b/helm/kre/templates/engine/entrypoint/nginx-ingress.yaml
@@ -13,7 +13,7 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-  {{- if .Values.entrypoint.tls -}}
+  {{- if .Values.entrypoint.tls }}
   tls:
     - hosts:
         - proto.{{ .Values.entrypoint.host }}


### PR DESCRIPTION
This fixes helm template chomps for `helm/kre/templates/engine/entrypoint/nginx-ingress.yaml` file