### PR TITLE
CI(Lint): New version for golangci-lint in mongoDB engine

### DIFF
--- a/.github/workflows/engine-mongo-writer_tests.yaml
+++ b/.github/workflows/engine-mongo-writer_tests.yaml
@@ -19,7 +19,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v2
         with:
-          version: v1.37
+          version: v1.45.2
           working-directory: ./engine/mongo-writer
           args: --timeout 5m
   test:


### PR DESCRIPTION
We wish to upgrade the current version for the golanci-lint inside our mongoDB engine.