### PR TITLE
ci: upgrade go and golangci-lint versions

### DIFF
--- a/.github/workflows/engine-mongo-writer_tests.yaml
+++ b/.github/workflows/engine-mongo-writer_tests.yaml
@@ -16,8 +16,12 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
+      - name: Install Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.18.x
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v2
+        uses: golangci/golangci-lint-action@v3
         with:
           version: v1.45.2
           working-directory: ./engine/mongo-writer
@@ -31,7 +35,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.14.x
+          go-version: 1.18.x
       - name: Test
         run: go test ./... -cover -v -coverprofile=coverage.out
         working-directory: ./engine/mongo-writer


### PR DESCRIPTION
We are having strange behaviours with the golangci-lint action. This PR upgrades the action to the latest version.