### PR TITLE
fix(ui): delete runtimesIDs from logs filters on ui

### DIFF
--- a/engine/admin-ui/src/Graphql/client/typeDefs.ts
+++ b/engine/admin-ui/src/Graphql/client/typeDefs.ts
@@ -13,7 +13,6 @@ export interface LogPanelFilters {
   nodes?: NodeSelection[];
   search?: string;
   levels?: LogLevel[] | null;
-  runtimesIds?: string[] | null;
   versionsIds?: string[] | null;
   workflowsNames?: string[] | null;
   __typename: 'logTabFilters';

--- a/engine/admin-ui/src/Graphql/hooks/useLogs.ts
+++ b/engine/admin-ui/src/Graphql/hooks/useLogs.ts
@@ -150,7 +150,6 @@ function useLogs() {
       filters: {
         ...getDefaultFilters(),
         nodes,
-        runtimesIds: [runtimeId],
         versionsIds: [versionId],
         workflowsNames: nodes.map(node => node.workflowName)
       }

--- a/engine/admin-ui/src/Pages/Version/pages/Status/LogsPanel/components/LogsList/LogsList.tsx
+++ b/engine/admin-ui/src/Pages/Version/pages/Status/LogsPanel/components/LogsList/LogsList.tsx
@@ -33,7 +33,6 @@ function getLogsQueryFilters(
     endDate: filterValues.endDate,
     search: filterValues.search,
     levels: filterValues.levels,
-    runtimesIds: filterValues?.runtimesIds ?? [],
     nodeIds:
       filterValues?.nodes
         ?.map(({ workflowName, nodeNames }) =>


### PR DESCRIPTION
### WHY

Logs filters fails on UI because one field of the request should be deleted.

### WHAT

Delete the runtimesIds field on logs filters.