### PR TITLE
fix(api): delete default runtime creation functionality

### DIFF
--- a/engine/admin-api/adapter/config/config.go
+++ b/engine/admin-api/adapter/config/config.go
@@ -56,9 +56,6 @@ type Config struct {
 	Services struct {
 		K8sManager string `yaml:"k8sManager" envconfig:"KRE_SERVICES_K8S_MANAGER"`
 	} `yaml:"services"`
-	Runtime struct {
-		Name string `yaml:"name" envconfig:"KRE_RUNTIME_NAME"`
-	} `yaml:"runtime"`
 }
 
 var once sync.Once

--- a/engine/admin-api/domain/usecase/runtime_interactor.go
+++ b/engine/admin-api/domain/usecase/runtime_interactor.go
@@ -135,34 +135,6 @@ func (i *RuntimeInteractor) createDatabaseIndexes(ctx context.Context, runtimeId
 	return i.versionRepo.CreateIndexes(ctx, runtimeId)
 }
 
-// EnsureRuntimeIsCreated creates the runtime in the DB if not exits
-func (i *RuntimeInteractor) EnsureRuntimeIsCreated(ctx context.Context) error {
-	r, err := i.runtimeRepo.GetByID(ctx, i.cfg.K8s.Namespace)
-	if err != nil && !errors.Is(err, ErrRuntimeNotFound) {
-		return err
-	}
-
-	if r != nil {
-		// NOTE: There already a runtime created
-		return nil
-	}
-
-	r = &entity.Runtime{
-		ID:          i.cfg.K8s.Namespace,
-		Name:        strings.TrimSpace(i.cfg.Runtime.Name),
-		Description: "Runtime description...",
-	}
-
-	createdRuntime, err := i.runtimeRepo.Create(ctx, r)
-	if err != nil {
-		i.logger.Errorf("Error creating runtime: %s", err)
-		return err
-	}
-	i.logger.Info("Runtime stored in the database with ID=" + createdRuntime.ID)
-
-	return nil
-}
-
 // Get return the current Runtime
 func (i *RuntimeInteractor) Get(ctx context.Context, loggedUserID string) (*entity.Runtime, error) {
 	if err := i.accessControl.CheckPermission(loggedUserID, auth.ResRuntime, auth.ActView); err != nil {

--- a/engine/admin-api/domain/usecase/runtime_interactor_test.go
+++ b/engine/admin-api/domain/usecase/runtime_interactor_test.go
@@ -37,8 +37,7 @@ type runtimeSuiteMocks struct {
 }
 
 const (
-	k8sNamespace       = "kre-test"
-	defaultRuntimeName = "kre-test-runtime"
+	k8sNamespace = "kre-test"
 )
 
 func newRuntimeSuite(t *testing.T) *runtimeSuite {
@@ -67,7 +66,6 @@ func newRuntimeSuite(t *testing.T) *runtimeSuite {
 	cfg := &config.Config{}
 
 	cfg.K8s.Namespace = k8sNamespace
-	cfg.Runtime.Name = defaultRuntimeName
 
 	runtimeInteractor := usecase.NewRuntimeInteractor(
 		cfg,

--- a/engine/admin-api/domain/usecase/runtime_interactor_test.go
+++ b/engine/admin-api/domain/usecase/runtime_interactor_test.go
@@ -272,27 +272,6 @@ func TestCreateNewRuntime_FailsIfCreateRuntimeFails(t *testing.T) {
 	require.Nil(t, runtime)
 }
 
-func TestEnsureRuntimeIsCreated(t *testing.T) {
-	s := newRuntimeSuite(t)
-	defer s.ctrl.Finish()
-
-	ctx := context.Background()
-
-	defaultRuntime := &entity.Runtime{
-		ID:           k8sNamespace,
-		Name:         defaultRuntimeName,
-		Description:  "Runtime description...",
-		CreationDate: time.Time{},
-	}
-
-	s.mocks.runtimeRepo.EXPECT().GetByID(ctx, k8sNamespace).Return(nil, usecase.ErrRuntimeNotFound)
-	s.mocks.runtimeRepo.EXPECT().Create(ctx, defaultRuntime).Return(defaultRuntime, nil)
-
-	err := s.runtimeInteractor.EnsureRuntimeIsCreated(ctx)
-
-	require.Nil(t, err)
-}
-
 func TestGetByID(t *testing.T) {
 	s := newRuntimeSuite(t)
 	defer s.ctrl.Finish()

--- a/engine/admin-api/main.go
+++ b/engine/admin-api/main.go
@@ -123,11 +123,6 @@ func main() {
 		panic(err)
 	}
 
-	err = runtimeInteractor.EnsureRuntimeIsCreated(context.Background())
-	if err != nil {
-		panic(err)
-	}
-
 	app := http.NewApp(
 		cfg,
 		logger,

--- a/helm/kre/CHART.md
+++ b/helm/kre/CHART.md
@@ -83,4 +83,3 @@
 | nats_streaming.storage.className | string | `"standard"` | Storage class name |
 | nats_streaming.storage.size | string | `"1Gi"` | Storage size |
 | rbac.create | bool | `true` | Whether to create the roles for the services that could use custom Service Accounts |
-| runtimeName | string | `"My Runtime"` | Runtime name |

--- a/helm/kre/templates/config/configmap.yaml
+++ b/helm/kre/templates/config/configmap.yaml
@@ -8,7 +8,6 @@ metadata:
     app.kubernetes.io/instance: {{ .Release.Name }}
 data:
   KRE_DEVELOPMENT_MODE: "{{ .Values.developmentMode }}"
-  KRE_RUNTIME_NAME: "{{ .Values.runtimeName }}"
   KRE_RELEASE_NAME: "{{ .Release.Name }}"
   # Runtime Entrypoint TLS
   KRE_ENTRYPOINT_TLS: "{{ .Values.entrypoint.tls }}"

--- a/helm/kre/values.yaml
+++ b/helm/kre/values.yaml
@@ -4,9 +4,6 @@ nameOverride: ""
 # -- Whether to setup developement mode
 developmentMode: false
 
-# -- Runtime name
-runtimeName: "My Runtime"
-
 rbac:
   # -- Whether to create the roles for the services that could use custom Service Accounts
   create: true


### PR DESCRIPTION
### WHY

Since the new multiruntimes approach allows users to create runtimes, a default runtime isn't needed anymore.

### WHAT

Delete default runtime creation when the api is started.