### PR TITLE
fix(k8s-manager): add krt-files-downloader images, tag and pull policy configurable via Helm

### DIFF
--- a/engine/k8s-manager/config/config.go
+++ b/engine/k8s-manager/config/config.go
@@ -60,6 +60,11 @@ type Config struct {
 			Size         string `yaml:"size" envconfig:"KRE_INFLUXDB_STORAGE_SIZE"`
 		} `yaml:"persistentVolume"`
 	} `yaml:"influxdb"`
+	KrtFilesDownloader struct {
+		Image      string `yaml:"image" envconfig:"KRE_KRT_FILES_DOWNLOADER_IMAGE"`
+		Tag        string `yaml:"tag" envconfig:"KRE_KRT_FILES_DOWNLOADER_TAG"`
+		PullPolicy string `yaml:"pullPolicy" envconfig:"KRE_KRT_FILES_DOWNLOADER_PULL_POLICY"`
+	} `yaml:"krtFilesDownloader"`
 }
 
 // NewConfig will read the config.yml file and override values with env vars.

--- a/engine/k8s-manager/kubernetes/version/containers.go
+++ b/engine/k8s-manager/kubernetes/version/containers.go
@@ -1,6 +1,9 @@
 package version
 
-import apiv1 "k8s.io/api/core/v1"
+import (
+	"fmt"
+	apiv1 "k8s.io/api/core/v1"
+)
 
 func (m *Manager) getFluentBitContainer(envVars []apiv1.EnvVar) apiv1.Container {
 	return apiv1.Container{
@@ -39,8 +42,8 @@ func (m *Manager) getFluentBitContainer(envVars []apiv1.EnvVar) apiv1.Container 
 func (m *Manager) getKRTFilesDownloaderContainer(envVars []apiv1.EnvVar) apiv1.Container {
 	return apiv1.Container{
 		Name:            "krt-files-downloader",
-		Image:           "konstellation/krt-files-downloader:latest",
-		ImagePullPolicy: apiv1.PullIfNotPresent,
+		Image:           fmt.Sprintf("%s:%s", m.config.KrtFilesDownloader.Image, m.config.KrtFilesDownloader.Tag),
+		ImagePullPolicy: apiv1.PullPolicy(m.config.KrtFilesDownloader.PullPolicy),
 		Env:             envVars,
 		VolumeMounts: []apiv1.VolumeMount{
 			m.getKRTFilesVolumeMount(),

--- a/helm/kre/CHART.md
+++ b/helm/kre/CHART.md
@@ -66,6 +66,9 @@
 | k8sManager.serviceAccount.annotations | object | `{}` | The Service Account annotations |
 | k8sManager.serviceAccount.create | bool | `true` | Whether to create the Service Account |
 | k8sManager.serviceAccount.name | string | `""` | The name of the service account. @default: A pre-generated name based on the chart relase fullname sufixed by `-k8s-manager` |
+| k8sManager.krtFilesDownloader.image.repository | string | `""` | Image repository for `krt-files-downloader` |
+| k8sManager.krtFilesDownloader.image.tag        | string | `""` | Image tag for `krt-files-downloader` |
+| k8sManager.krtFilesDownloader.image.pullPolicy | string | `""` | Image pull policy for `krt-files-downloader` |
 | kapacitor.enabled | bool | `false` | Whether to enable Kapacitor |
 | kapacitor.persistence.enabled | bool | `false` | Whether to enable persistence [Details](https://github.com/influxdata/helm-charts/blob/master/charts/kapacitor/values.yaml) |
 | mongoWriter.image.pullPolicy | string | `"IfNotPresent"` | Image pull policy |

--- a/helm/kre/templates/config/configmap.yaml
+++ b/helm/kre/templates/config/configmap.yaml
@@ -45,3 +45,7 @@ data:
   KRE_INFLUXDB_ADDRESS: {{ include "runtime.influxURL" . }}
   KRE_INFLUXDB_STORAGECLASS: "{{ .Values.influxdb.persistence.storageClass }}"
   KRE_INFLUXDB_STORAGE_SIZE: "{{ .Values.influxdb.persistence.size }}"
+  #KRTFilesDownloader
+  KRE_KRT_FILES_DOWNLOADER_IMAGE: "{{ .Values.k8sManager.krtFilesDownloader.image.repository }}"
+  KRE_KRT_FILES_DOWNLOADER_TAG: "{{ .Values.k8sManager.krtFilesDownloader.image.tag }}"
+  KRE_KRT_FILES_DOWNLOADER_PULL_POLICY: "{{ .Values.k8sManager.krtFilesDownloader.image.pullPolicy }}"

--- a/helm/kre/values.yaml
+++ b/helm/kre/values.yaml
@@ -189,6 +189,14 @@ k8sManager:
     name: ""
     # -- The Service Account annotations
     annotations: {}
+  krtFilesDownloader:
+    image:
+      # -- Image repository for `krt-files-downloader`
+      repository: konstellation/krt-files-downloader
+      # -- Image tag for `krt-files-downloader`
+      tag: latest
+      # -- Image pull policy for `krt-files-downloader`
+      pullPolicy: Always
 
 mongoWriter:
   image:


### PR DESCRIPTION
### WHY

`krt-files-downloader` deployment have pull policy "PullIfNotPresent", so, when the tag is latest (as it should be in integrated), the new versions of this component aren't pulled.

### WHAT

Make the image, the tag and the pull policy configurable via Helm in the `k8s-manager` configuration.