### PR TITLE
fix(k8s-manager): delete created ingress on unpublish version

### DIFF
--- a/engine/k8s-manager/kubernetes/version/ingress.go
+++ b/engine/k8s-manager/kubernetes/version/ingress.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
-
 	"gopkg.in/yaml.v2"
 	v1 "k8s.io/api/networking/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -37,6 +36,15 @@ func (m *Manager) ensureIngressCreated(ctx context.Context, name, runtimeID, act
 		return err
 	}
 
+	return nil
+}
+
+func (m *Manager) deleteIngress(ctx context.Context, name string) error {
+	m.logger.Infof("Deleting ingress %s", name)
+	err := m.clientset.NetworkingV1().Ingresses(m.config.Kubernetes.Namespace).Delete(ctx, name, metav1.DeleteOptions{})
+	if err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -131,4 +139,8 @@ func (m *Manager) getTLSCertSecretName(entrypointHost string) string {
 		return m.config.Entrypoint.TLS.CertSecretName
 	}
 	return fmt.Sprintf("%s-tls", entrypointHost)
+}
+
+func (m *Manager) getIngressName(runtimeID string) string {
+	return fmt.Sprintf("%s-%s-entrypoint", m.config.ReleaseName, runtimeID)
 }

--- a/engine/k8s-manager/kubernetes/version/manager.go
+++ b/engine/k8s-manager/kubernetes/version/manager.go
@@ -100,7 +100,7 @@ func (m *Manager) Publish(ctx context.Context, req *versionpb.VersionInfo) error
 	m.logger.Infof("Publish version '%s' on runtime '%s'", req.Name, req.RuntimeId)
 
 	activeServiceName := fmt.Sprintf("%s-%s", req.RuntimeId, activeEntrypointSuffix)
-	ingressName := fmt.Sprintf("%s-%s-entrypoint", m.config.ReleaseName, req.RuntimeId)
+	ingressName := m.getIngressName(req.RuntimeId)
 
 	err := m.ensureIngressCreated(ctx, ingressName, req.RuntimeId, activeServiceName)
 	if err != nil {
@@ -144,7 +144,14 @@ func (m *Manager) Publish(ctx context.Context, req *versionpb.VersionInfo) error
 // The service-name will be changed to `VERSIONNAME-entrypoint`
 func (m *Manager) Unpublish(ctx context.Context, req *versionpb.VersionInfo) error {
 	m.logger.Infof("Deactivating version '%s' on runtime '%s'", req.Name, req.RuntimeId)
-	err := m.deleteActiveEntrypointService(ctx, req.RuntimeId)
+
+	ingressName := m.getIngressName(req.RuntimeId)
+	err := m.deleteIngress(ctx, ingressName)
+	if err != nil {
+		return err
+	}
+
+	err = m.deleteActiveEntrypointService(ctx, req.RuntimeId)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
### WHY

When a version is unpublished, the ingress created when it was published is useless, so deleting it keeps the environment cleaner.

### WHAT

Add function to remove ingress on k8s-manager.