### PR TITLE
fix(mongo-writer): load configmap with NATS URL

### DIFF
--- a/helm/kre/templates/engine/mongo-writer/deployment.yaml
+++ b/helm/kre/templates/engine/mongo-writer/deployment.yaml
@@ -19,5 +19,7 @@ spec:
           image: {{ .Values.mongoWriter.image.repository }}:{{ .Values.mongoWriter.image.tag }}
           imagePullPolicy: {{ .Values.mongoWriter.image.pullPolicy }}
           envFrom:
+            - configMapRef:
+                name: {{ .Release.Name }}-configmap
             - secretRef:
                 name: {{ .Release.Name }}-secrets


### PR DESCRIPTION
### WHY

mongo-writer throws an error when trying to connect to NATS.

### WHAT

Load ConfigMap with the correct NATS URL.