### PR TITLE
fix(mongo-writer): load configmap with NATS URL (#648)

### DIFF
--- a/helm/kre/templates/engine/mongo-writer/deployment.yaml
+++ b/helm/kre/templates/engine/mongo-writer/deployment.yaml
@@ -19,5 +19,7 @@ spec:
           image: {{ .Values.mongoWriter.image.repository }}:{{ .Values.mongoWriter.image.tag }}
           imagePullPolicy: {{ .Values.mongoWriter.image.pullPolicy }}
           envFrom:
+            - configMapRef:
+                name: {{ .Release.Name }}-configmap
             - secretRef:
                 name: {{ .Release.Name }}-secrets


### PR DESCRIPTION
This fix is needed because nats URL was hardcoded and mongo-writter isn't able to reach kre-local-nats