### PR TITLE
fix(admin-api): format runtime's influx db name to avoid issues with hyphens

### DIFF
--- a/engine/admin-api/adapter/repository/influx/measurement.go
+++ b/engine/admin-api/adapter/repository/influx/measurement.go
@@ -23,7 +23,7 @@ func NewMeasurementRepoInfluxDB(cfg *config.Config, logger logging.Logger) *Meas
 }
 
 func (m *MeasurementRepoInfluxDB) CreateDatabase(runtimeId string) error {
-	createDatabaseCommand := "CREATE DATABASE " + runtimeId
+	createDatabaseCommand := fmt.Sprintf("CREATE DATABASE \"%s\"", runtimeId)
 	query, err := m.generateQuery(createDatabaseCommand)
 	if err != nil {
 		return err


### PR DESCRIPTION
### WHY

When user creates a runtime with hyphens in its ID, InfluxDB throws an error because the request to create a new database doesn't format the name correctly.

### WHAT

Surround the database name in colons to avoid errors on the request.