### PR TITLE
fix(admin-api): reverse proxy for mongo-express and chronograf

### DIFF
--- a/engine/admin-api/adapter/config/config.go
+++ b/engine/admin-api/adapter/config/config.go
@@ -51,6 +51,10 @@ type Config struct {
 	InfluxDB struct {
 		Address string `yaml:"address" envconfig:"KRE_INFLUXDB_ADDRESS"`
 	} `yaml:"influxdb"`
+	Chronograf struct {
+		Address string `yaml:"address" envconfig:"KRE_CHRONOGRAF_ADDRESS"`
+	} `yaml:"chronograf"`
+
 	K8s struct {
 		Namespace string `yaml:"namespace" envconfig:"POD_NAMESPACE"`
 	} `yaml:"k8s"`

--- a/engine/admin-api/adapter/service/chronograf.go
+++ b/engine/admin-api/adapter/service/chronograf.go
@@ -5,10 +5,11 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/konstellation-io/kre/engine/admin-api/adapter/config"
 	"io/ioutil"
 	"net/http"
 	"os"
+
+	"github.com/konstellation-io/kre/engine/admin-api/adapter/config"
 
 	domainService "github.com/konstellation-io/kre/engine/admin-api/domain/service"
 	"github.com/konstellation-io/kre/engine/admin-api/domain/usecase/logging"
@@ -66,8 +67,8 @@ func (c *Chronograf) Create(ctx context.Context, runtimeId, version, dashboardPa
 
 	requestReader := bytes.NewReader(requestByte)
 
-	chronografURL := fmt.Sprintf("http://chronograf.%s/measurements/%s/chronograf/v1/dashboards",
-		c.cfg.K8s.Namespace, c.cfg.K8s.Namespace)
+	chronografURL := fmt.Sprintf("%s/measurements/%s/chronograf/v1/dashboards",
+		c.cfg.Chronograf.Address, c.cfg.K8s.Namespace)
 
 	r, err := http.NewRequest(http.MethodPost, chronografURL, requestReader)
 	if err != nil {

--- a/engine/admin-api/config.yml
+++ b/engine/admin-api/config.yml
@@ -23,6 +23,8 @@ mongodb:
   krtBucket: "krt"
 influxdb:
   address: "http://localhost:8086"
+chronograf:
+  address: "http://localhost:8888"
 k8s:
   namespace: ""
 services:

--- a/engine/admin-api/delivery/http/middleware/chronograf_proxy.go
+++ b/engine/admin-api/delivery/http/middleware/chronograf_proxy.go
@@ -1,12 +1,10 @@
 package middleware
 
 import (
-	"errors"
-	"fmt"
-	"github.com/labstack/echo"
-	"net/http"
 	"net/url"
 	"regexp"
+
+	"github.com/labstack/echo"
 )
 
 var measurementsURLRegexp = regexp.MustCompile("^/measurements/([^/]+)")
@@ -15,14 +13,7 @@ var measurementsURLRegexp = regexp.MustCompile("^/measurements/([^/]+)")
 // to one of the runtime's Chronograf service.
 // The incoming request are like: "<api_base_url>/measurements/<runtime-name>/*"
 // and the destination URLs: "http://chronograf.<runtime-name>/measurements/<runtime-name>/*"
-func ChronografProxy() echo.MiddlewareFunc {
-	return NewReverseProxyWithDynamicURLTarget(func(req *http.Request) (*url.URL, error) {
-		matches := measurementsURLRegexp.FindStringSubmatch(req.URL.Path)
-		if matches == nil {
-			return nil, errors.New("required runtime path param not found")
-		}
-
-		runtime := matches[1]
-		return url.Parse(fmt.Sprintf("http://chronograf.%s", runtime))
-	})
+func ChronografProxy(chronografAddress string) echo.MiddlewareFunc {
+	destinationURL, _ := url.Parse(chronografAddress)
+	return NewReverseProxyWithDynamicURLTarget(destinationURL)
 }

--- a/engine/admin-api/delivery/http/middleware/mongoexpress_proxy.go
+++ b/engine/admin-api/delivery/http/middleware/mongoexpress_proxy.go
@@ -14,6 +14,6 @@ var databaseURLRegexp = regexp.MustCompile("^/database/([^/]+)")
 // The incoming request are like: "<api_base_url>/database/<runtime-name>/*"
 // and the destination URLs: "http://kre-mongo-express.<k8s-namespace>/database/<runtime-name>/*"
 func MongoExpressProxy(mongoExpressAddress string) echo.MiddlewareFunc {
-	detinationURL, _ := url.Parse(mongoExpressAddress)
-	return NewReverseProxyWithDynamicURLTarget(detinationURL)
+	destinationURL, _ := url.Parse(mongoExpressAddress)
+	return NewReverseProxyWithDynamicURLTarget(destinationURL)
 }

--- a/engine/admin-api/delivery/http/middleware/mongoexpress_proxy.go
+++ b/engine/admin-api/delivery/http/middleware/mongoexpress_proxy.go
@@ -1,9 +1,6 @@
 package middleware
 
 import (
-	"errors"
-	"fmt"
-	"net/http"
 	"net/url"
 	"regexp"
 
@@ -17,15 +14,6 @@ var databaseURLRegexp = regexp.MustCompile("^/database/([^/]+)")
 // The incoming request are like: "<api_base_url>/database/<runtime-name>/*"
 // and the destination URLs: "http://kre-mongo-express.<k8s-namespace>/database/<runtime-name>/*"
 func MongoExpressProxy(mongoExpressAddress string) echo.MiddlewareFunc {
-	return NewReverseProxyWithDynamicURLTarget(func(req *http.Request) (*url.URL, error) {
-		matches := databaseURLRegexp.FindStringSubmatch(req.URL.Path)
-		if matches == nil {
-			return nil, errors.New("required runtime path param not found")
-		}
-
-		k8sNamespace := matches[1]
-		destinationURL, _ := url.Parse(fmt.Sprintf("http://%s.%s", mongoExpressAddress, k8sNamespace))
-		fmt.Println(destinationURL)
-		return destinationURL, nil
-	})
+	detinationURL, _ := url.Parse(mongoExpressAddress)
+	return NewReverseProxyWithDynamicURLTarget(detinationURL)
 }

--- a/engine/admin-api/delivery/http/middleware/reverse_proxy.go
+++ b/engine/admin-api/delivery/http/middleware/reverse_proxy.go
@@ -15,18 +15,11 @@ type GetTargetURL = func(req *http.Request) (*url.URL, error)
 // NewReverseProxyWithDynamicURLTarget creates a reverse proxy Echo middleware
 // that instead of having a static list of target URLs gets the target URL dynamically
 // depending of the request information.
-func NewReverseProxyWithDynamicURLTarget(getTargetURL GetTargetURL) echo.MiddlewareFunc {
+func NewReverseProxyWithDynamicURLTarget(targetURL *url.URL) echo.MiddlewareFunc {
 	return func(next echo.HandlerFunc) echo.HandlerFunc {
 		return func(c echo.Context) (err error) {
 			req := c.Request()
 			res := c.Response()
-
-			targetURL, err := getTargetURL(req)
-			if err != nil {
-				c.Logger().Errorf("invalid target URL=%s", err)
-				c.Error(echo.NewHTTPError(http.StatusBadRequest))
-				return
-			}
 
 			// Fix header
 			if req.Header.Get(echo.HeaderXRealIP) == "" {

--- a/engine/admin-api/delivery/http/server.go
+++ b/engine/admin-api/delivery/http/server.go
@@ -120,7 +120,7 @@ func NewApp(
 	m := e.Group("/measurements")
 	m.Use(jwtCookieMiddleware)
 	m.Use(sessionMiddleware)
-	m.Use(kremiddleware.ChronografProxy())
+	m.Use(kremiddleware.ChronografProxy(cfg.Chronograf.Address))
 
 	d := e.Group("/database")
 	d.Use(jwtCookieMiddleware)

--- a/helm/kre/templates/engine/admin-api/configmap.yaml
+++ b/helm/kre/templates/engine/admin-api/configmap.yaml
@@ -13,7 +13,7 @@ data:
   KRE_ADMIN_API_BASE_URL: "{{ $protocol }}://{{ .Values.config.admin.apiHost }}"
   KRE_ADMIN_CORS_ENABLED: "{{ .Values.config.admin.corsEnabled }}"
   KRE_SERVICES_K8S_MANAGER: "{{ .Release.Name }}-k8s-manager:50051"
-  KRE_MONGODB_MONGOEXPRESS_ADDRESS: {{ include "mongoExpress.name" . }}
+  KRE_MONGODB_MONGOEXPRESS_ADDRESS: http://{{ include "mongoExpress.name" . }}
   KRE_BASE_DOMAIN_NAME: {{ .Values.config.baseDomainName }}
   KRE_ADMIN_STORAGE_PATH: {{ .Values.adminApi.storage.path }}
   KRE_ADMIN_API_ADDRESS: ":8080"
@@ -29,5 +29,7 @@ data:
   KRE_AUTH_VERIFICATION_CODE_DURATION_IN_MINUTES: "{{ .Values.config.auth.verificationCodeDurationInMinutes }}"
   KRE_AUTH_SECURE_COOKIE: "{{ .Values.config.auth.secureCookie }}"
   KRE_AUTH_COOKIE_DOMAIN: "{{ .Values.config.auth.cookieDomain }}"
-  #InfluxDB
+  # InfluxDB
   KRE_INFLUXDB_ADDRESS: {{ include "kre-influxdb.influxURL" . }}
+  # Chronograf
+  KRE_CHRONOGRAF_ADDRESS: "http://{{ .Release.Name }}-chronograf"


### PR DESCRIPTION
This PR introduces the following changes:

* Fix chronograf reverse proxy as it was using a hardcoded hostname for the proxied server
* Refactor of `NewReverseProxyWithDynamicURLTarget` go function that was not adapted to multi-runtime as it is defined now.