### PR TITLE
ci: add nats-manager's test and release actions

### DIFF
--- a/.github/workflows/build_release.yaml
+++ b/.github/workflows/build_release.yaml
@@ -146,6 +146,52 @@ jobs:
             konstellation/kre-k8s-manager:${{ steps.get_version.outputs.VERSION }}
             konstellation/kre-k8s-manager:latest
 
+  docker-nats-manager:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Login to DockerHub Registry
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Get Version
+        id: get_version
+        run: echo "VERSION=${GITHUB_REF#refs/tags/}" >> ${GITHUB_OUTPUT}
+
+      - name: Push to Docker Hub RELEASE
+        if: ${{ ! contains( github.event.ref, 'alpha' ) }}
+        uses: docker/build-push-action@v3
+        with:
+          context: ./engine/nats-manager
+          file: ./engine/nats-manager/Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: |
+            konstellation/kre-nats-manager:${{ steps.get_version.outputs.VERSION }}
+
+      - name: Push to Docker Hub ALPHA
+        if: ${{ contains( github.event.ref, 'alpha' ) }}
+        uses: docker/build-push-action@v3
+        with:
+          context: ./engine/nats-manager
+          file: ./engine/nats-manager/Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: |
+            konstellation/kre-nats-manager:${{ steps.get_version.outputs.VERSION }}
+            konstellation/kre-nats-manager:latest
+
   docker-mongo-writer:
     runs-on: ubuntu-latest
     steps:
@@ -200,6 +246,7 @@ jobs:
       - docker-admin-ui
       - docker-k8s-manager
       - docker-mongo-writer
+      - docker-nats-manager
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/engine-nats-manager_tests.yaml
+++ b/.github/workflows/engine-nats-manager_tests.yaml
@@ -1,0 +1,52 @@
+name: ENGINE nats-manager Tests
+
+on:
+  push:
+    branches-ignore:
+      - "v*"
+    tags-ignore:
+      - v*
+    paths:
+      - "engine/nats-manager/**/*"
+      - ".github/workflows/admin-nats-manager*"
+
+jobs:
+  test:
+    name: Tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+      - name: Install Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: 1.18.x
+      - name: Test
+        run: go test ./... -cover -v -coverprofile=coverage.out
+        working-directory: ./engine/nats-manager
+      - name: Archive code coverage results
+        uses: actions/upload-artifact@v3
+        with:
+          name: coverage-report
+          path: engine/nats-manager/coverage.out
+
+  sonarcloud:
+    name: SonarCloud
+    runs-on: ubuntu-latest
+    needs: test
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
+      - name: Download code coverage results
+        uses: actions/download-artifact@v3
+        with:
+          name: coverage-report
+          path: engine/nats-manager
+      - name: SonarCloud Scan
+        uses: SonarSource/sonarcloud-github-action@master
+        with:
+          projectBaseDir: engine/nats-manager
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN_K8S_MANAGER }}


### PR DESCRIPTION
# WHY

I want to build and release nats-manager images on CI/CD pipeline.

# WHAT

Create GitHub Actions for testing and release nats-manager.