### PR TITLE
fix(nats-manager): replace log message on GetVersionNatsConfig service

### DIFF
--- a/engine/nats-manager/service/nats.go
+++ b/engine/nats-manager/service/nats.go
@@ -65,7 +65,7 @@ func (n *NatsService) GetVersionNatsConfig(
 	_ context.Context,
 	req *natspb.GetVersionNatsConfigRequest,
 ) (*natspb.GetVersionNatsConfigResponse, error) {
-	n.logger.Info("Stop request received")
+	n.logger.Info("GetVersionNatsConfig request received")
 
 	workflowNatsConfig, err := n.manager.GetVersionNatsConfig(req.RuntimeId, req.VersionName, req.Workflows)
 	if err != nil {

--- a/engine/nats-manager/sonar-project.properties
+++ b/engine/nats-manager/sonar-project.properties
@@ -1,0 +1,16 @@
+sonar.projectKey=konstellation-io_kre_nats-manager
+sonar.organization=konstellation-io
+
+# This is the name and version displayed in the SonarCloud UI.
+sonar.projectName=KRE - NATS Manager
+sonar.projectVersion=1.0
+
+# Path is relative to the sonar-project.properties file. Replace "\" by "/" on Windows.
+sonar.sources=.
+sonar.exclusions=**/*_test.go,**/*.pb.go,**/mocks/*,mocks/*
+sonar.tests=.
+sonar.test.inclusions=**/*_test.go
+
+sonar.go.coverage.reportPaths=./coverage.out
+# Encoding of the source code. Default is default system encoding
+sonar.sourceEncoding=UTF-8


### PR DESCRIPTION
# WHY

Log indicated that Stop service is beeing executed instead of GetVersionNatsConfig service. Also, I want to force a new image release on nats-manager.

# WHAT

Change the log message.