### PR TITLE
fix(admin-ui): add exitpoint field to v1 workflows and entrypoint to first node subs

### DIFF
--- a/engine/admin-ui/src/Pages/Version/pages/Status/Status.tsx
+++ b/engine/admin-ui/src/Pages/Version/pages/Status/Status.tsx
@@ -84,6 +84,7 @@ function Status({ version, runtime }: Props) {
       .map(workflow => (
         {
           ...workflow,
+          exitpoint: "exitpoint",
           nodes: [
             ...workflow.nodes
               .map((node) => {
@@ -91,7 +92,7 @@ function Status({ version, runtime }: Props) {
                 const nodeName = edgeToNode && workflow.nodes.find(n => n.id === edgeToNode.fromNode)?.name
                 return {
                   ...node,
-                  subscriptions: edgeToNode && nodeName ? [nodeName]: [],
+                  subscriptions: edgeToNode && nodeName ? [nodeName]: ["entrypoint"],
                 }
               }),
             {

--- a/engine/admin-ui/src/Pages/Version/pages/Status/components/BranchedWorkflowChart/BranchedWorkflowChart.tsx
+++ b/engine/admin-ui/src/Pages/Version/pages/Status/components/BranchedWorkflowChart/BranchedWorkflowChart.tsx
@@ -35,8 +35,6 @@ function BranchedWorkflowChart({
   const maxNodesSubs = getMaxNodesSubs(workflow?.nodes);
   const myGraphRef = useRef<ForceGraphMethods>();
 
-  console.log(workflow)
-
   useEffect(() => {
     myGraphRef.current?.d3Force('link', forceLink().distance(maxNodesSubs > 1 ? 90 / maxNodesSubs: 40));
     myGraphRef.current?.d3Force('charge', forceManyBody().strength(-50*maxNodesSubs));


### PR DESCRIPTION
# WHY

UI couldn't draw v1 graphs properly because no exitpoint was defined and the first node hadn't the entrypoint in his subscriptions list.

# WHAT

Add exitpoint default node name to workflow configuration and entrypoint to first node subscriptions during v1 to v2 translations on UI.