### PR TITLE
fix(engine-ui): add exitpoint status to v1 versions

### DIFF
--- a/engine/admin-ui/src/Graphql/subscriptions/types/WatchVersionNodeStatus.ts
+++ b/engine/admin-ui/src/Graphql/subscriptions/types/WatchVersionNodeStatus.ts
@@ -12,6 +12,7 @@ import { NodeStatus } from './../../types/globalTypes';
 export interface WatchVersionNodeStatus_watchNodeStatus {
   __typename: 'Node';
   id: string;
+  name: string;
   status: NodeStatus;
 }
 

--- a/engine/admin-ui/src/Graphql/subscriptions/watchVersionNodeStatus.ts
+++ b/engine/admin-ui/src/Graphql/subscriptions/watchVersionNodeStatus.ts
@@ -4,6 +4,7 @@ export default gql`
   subscription WatchVersionNodeStatus($versionName: String!, $runtimeId: ID!) {
     watchNodeStatus(versionName: $versionName, runtimeId: $runtimeId) {
       id
+      name
       status
     }
   }

--- a/engine/admin-ui/src/Pages/Version/pages/Status/Status.tsx
+++ b/engine/admin-ui/src/Pages/Version/pages/Status/Status.tsx
@@ -34,6 +34,8 @@ type Props = {
   runtime?: GetVersionConfStatus_runtime;
 };
 
+const defaultExitpointV1 = "konstellation-exitpoint";
+
 function Status({ version, runtime }: Props) {
   const { versionName, runtimeId } = useParams<VersionRouteParams>();
   const { updateEntrypointStatus } = useOpenedVersion();
@@ -51,6 +53,8 @@ function Status({ version, runtime }: Props) {
   const entrypointStatus =
     dataOpenedVersion.entrypointStatus || NodeStatus.STOPPED;
 
+  const [exitpointStatus, setExitpointStatus] = useState<NodeStatus>(NodeStatus.STOPPED);
+
   const subscribe = () =>
     subscribeToMore<WatchVersionNodeStatus, WatchVersionNodeStatusVariables>({
       document: VersionNodeStatusSubscription,
@@ -59,6 +63,9 @@ function Status({ version, runtime }: Props) {
         const node = subscriptionData.data.watchNodeStatus;
         if (node.id === 'entrypoint') {
           updateEntrypointStatus(node.status);
+        }
+        if (node.name === defaultExitpointV1) {
+          setExitpointStatus(node.status)
         }
 
         return prev;
@@ -84,7 +91,7 @@ function Status({ version, runtime }: Props) {
       .map(workflow => (
         {
           ...workflow,
-          exitpoint: "exitpoint",
+          exitpoint: defaultExitpointV1,
           nodes: [
             ...workflow.nodes
               .map((node) => {
@@ -98,8 +105,8 @@ function Status({ version, runtime }: Props) {
             {
               __typename: 'Node' as 'Node',
               id: 'exitpoint',
-              name: 'exitpoint',
-              status: NodeStatus.STOPPED,
+              name: defaultExitpointV1,
+              status: exitpointStatus,
               subscriptions: workflow.nodes.map(node => node.name),
             },
           ]


### PR DESCRIPTION
# WHY

Status for the default exitpoint node created in v1 versions wasn't beeing represented correctly in the graph.

# WHAT

Manage exitpoint status with useState hook.