### PR TITLE
ci(admin-ui): update deprecated gh workflow syntax

### DIFF
--- a/.github/workflows/build_release.yaml
+++ b/.github/workflows/build_release.yaml
@@ -75,7 +75,7 @@ jobs:
 
       - name: Get Version
         id: get_version
-        run: echo ::set-output name=VERSION::${GITHUB_REF#refs/tags/}
+        run: echo "VERSION=${GITHUB_REF#refs/tags/}" >> ${GITHUB_OUTPUT}
 
       - name: Push to Docker Hub RELEASE
         if: ${{ ! contains( github.event.ref, 'alpha' ) }}


### PR DESCRIPTION
Remove the use of `set-output` command in favor of `GITHUB_OUTPUT` environment file. 