### PR TITLE
feat(scripts): add make-kre-user-admin.sh script

### DIFF
--- a/scripts/make-kre-user-admin.sh
+++ b/scripts/make-kre-user-admin.sh
@@ -1,0 +1,81 @@
+#!/bin/sh
+# ----
+# File:        make-kre-user-admin.sh
+# Description: Script to make an existing user ADMIN on the KRE database.
+#              The script takes an email as input and prints the updated line
+#              if the change is applied.
+# Author:      Sergio Talens-Oliag <sergio.talens@intelygenz.com>
+# ----
+
+set -e
+
+# ---------
+# FUNCTIONS
+# ---------
+
+usage() {
+  cat <<EOF
+
+Usage: $0 EMAIL
+
+On a new development environment call:
+
+  $0 dev@local.local
+
+EOF
+  exit "$1"
+}
+
+# ----
+# MAIN
+# ----
+
+# Default return value
+ret=0
+
+# Process arguments
+EMAIL="$1"
+
+case "$EMAIL" in
+*@*) ;;
+"") usage 0 ;;
+*) usage 1 ;;
+esac
+
+# Get mongodb password
+PASS="$(
+  kubectl get -n kre secrets/mongodb-database-admin-password \
+  -o jsonpath="{.data.password}" | base64 --decode
+)" || true
+
+
+if [ "$PASS" ]; then
+  # Update user command
+  UPDT_ARGS="{\"email\":\"$EMAIL\"}, {\$set: {\"accessLevel\": \"ADMIN\"}}"
+  UPDT_CMND="db.users.updateOne($UPDT_ARGS)"
+  # Find user command
+  FIND_ARGS="{\"email\":\"$EMAIL\"}"
+  FIND_CMND="db.users.find($FIND_ARGS)"
+  # Combined command (update and then find)
+  CMND="$UPDT_CMND; $FIND_CMND"
+  # Execute mongo command on the mongodb server container, if there is no
+  # output the user was not found
+  OUTPUT="$(
+    kubectl exec -ti pod/mongodb-database-0 -c mongod -- mongo --quiet \
+      -u admin -p "$PASS" --authenticationDatabase admin kre --eval "$CMND"
+  )"
+  if [ "$OUTPUT" ]; then
+    echo "$OUTPUT"
+  else
+    echo "User '$EMAIL' not found"
+    ret=1
+  fi
+else
+  echo "No mongodb password found, aborting!"
+  ret=1
+fi
+
+exit "$ret"
+
+# ----
+# vim: ts=2:sw=2:et:ai:sts=2


### PR DESCRIPTION
Added a script to make a user `ADMIN` on the KRE `mongodb` database

## Description
The script uses `kubectl` to get the `mongodb` admin password and executes the `mongo` cli on a container to update the user with the `email` address passed as argument if it exists, printing the updated data if succeeds.

## Motivation and Context
I was going to do the change manually and thought that with this command I don't need to remember it anymore.

The command executes the code on a container to simplify things (no need to use port forwarding nor installing the `mongo` cli locally).

I haven't updated the documentation yet, if the addition is OK I guess it has to be documented somewhere (i.e. probably this [section](https://github.com/konstellation-io/konstellation-infrastructure/blob/main/README.md#important-steps-after-redeploying-the-demo-application) of the `konstellation-infrastructure/README.md` should be changed).

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other changes (ci configuration, documentation or any other kind of changes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have created tests for my code changes, and the tests are passing.
- [ ] I have executed the pre-commit hooks locally.
- [x] My change requires a change to the documentation (create a new issue if the documentation has not been updated).
- [ ] I have updated the documentation accordingly.
